### PR TITLE
Remove rspec task from rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,4 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
-  task default: :spec
-rescue LoadError
-  $stderr.puts 'RSpec not available. Not running specs.'
-end
+# default task is rspec, as defined by rspec-rails


### PR DESCRIPTION
Should fix #12. Rspec-rails already defines a task `spec` and sets it as default, so when we define one as well, both are run. Unfortunately this already defined task can not be run by using `rake spec`, so the only way to run the specs is by running `rake`.