### PR TITLE
8 create capistrano tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+config/database.yml export-ignore
+config/secrets.yml  export-ignore

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   username: postgres
   # password:
-  host: localhost # Optional
+  # host: localhost # Optional
   port: 5432 # Optional
   template: template0
   encoding: utf8 # Optional


### PR DESCRIPTION
This shall prepare for #8. The tasks themselves will be in another repository: [ontohub-deployment](https://github.com/ontohub/ontohub-deployment)

We don't want the database.yml and the secrets.yml to be deployed. This is restricted in the .gitattributes file.

We should not specify the host in the database.yml. If we explicitly set one, postgres uses another authorization method and the to-be-deployed application cannot connect to the database. This change is just about setting a reasonable default.