### PR TITLE
Send correct namespace slug

### DIFF
--- a/app/serializers/v2/repository_serializer.rb
+++ b/app/serializers/v2/repository_serializer.rb
@@ -9,7 +9,7 @@ module V2
     has_one :namespace, serializer: V2::NamespaceSerializer do
       link :related do
         url_for(controller: 'v2/namespaces', action: 'show',
-                slug: object.to_param)
+                slug: object.namespace.to_param)
       end
     end
 


### PR DESCRIPTION
The repository serializer sent the repository slug instead of the namespace slug.