### PR TITLE
Remove repositories data

### DIFF
--- a/app/serializers/v2/namespace_serializer.rb
+++ b/app/serializers/v2/namespace_serializer.rb
@@ -10,7 +10,8 @@ module V2
               slug: object.to_param)
     end
 
-    has_many :repositories, serializer: V2::RepositorySerializer do
+    has_many :repositories do
+      include_data false
       link :related do
         url_for(controller: 'v2/repositories', action: 'index',
                 namespace_slug: object.to_param)

--- a/spec/support/api/v2/schemas/repository_relationship_object.json
+++ b/spec/support/api/v2/schemas/repository_relationship_object.json
@@ -7,16 +7,8 @@
   "definitions": {
     "repository": {
       "type": "object",
-      "required": ["data", "links"],
+      "required": ["links"],
       "properties": {
-        "data": {
-          "type": "array",
-          "required": ["id", "type"],
-          "items": {
-            "id": {"type": "string"},
-            "type": {"type": "string"}
-          }
-        },
         "links": {
           "type": "object",
           "required": ["related"],


### PR DESCRIPTION
This removes the `data` key for the repositories association. This has the effect, that Ember will use the given `link` URL to load repositories in a namespace instead of querying by IDs.