### PR TITLE
21 repository controller returns repositories of all namespaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: fd02bfafc894154079e10ec64881099eb1b1a06c
+  revision: c6946a3d9b35b31d33d2b3a02628bd4217e98e40
   branch: master
   specs:
     ontohub-models (0.1.0)

--- a/app/controllers/v2/repositories_controller.rb
+++ b/app/controllers/v2/repositories_controller.rb
@@ -16,5 +16,21 @@ module V2
       resource_params[:namespace_id] = namespace&.id
       super
     end
+
+    protected
+
+    def parent_params
+      return @parent_params unless @parent_params.nil?
+
+      # parse params - namespace_slug for index route, slug for other routes
+      parts = (params[:slug] || params[:namespace_slug]).split('/', 2)
+      namespace_id = Namespace.find(slug: parts.first)&.id
+      @parent_params = super.merge(namespace_id: namespace_id)
+
+      # update params
+      @parent_params.each { |key, value| params[key] = value }
+
+      @parent_params
+    end
   end
 end

--- a/app/controllers/v2/resources_controller/resources_helpers.rb
+++ b/app/controllers/v2/resources_controller/resources_helpers.rb
@@ -9,14 +9,21 @@ module V2
         def collection
           return @collection if @collection
           klass = self.class.instance_variable_get(:@resource_class)
-          @collection = klass.all
+          @collection = klass.where(parent_params).all
         end
 
         def resource
           return @resource if @resource
           klass = self.class.instance_variable_get(:@resource_class)
           find_param = self.class.instance_variable_get(:@find_param)
-          @resource = klass.find(find_param => params[find_param])
+          @resource = klass.find(find_param => params[find_param],
+                                 **parent_params)
+        end
+
+        protected
+
+        def parent_params
+          {}
         end
       end
 

--- a/app/serializers/v2/namespace_serializer.rb
+++ b/app/serializers/v2/namespace_serializer.rb
@@ -19,7 +19,7 @@ module V2
     end
 
     def id
-      object.slug
+      object.to_param
     end
   end
 end

--- a/app/serializers/v2/repository_serializer.rb
+++ b/app/serializers/v2/repository_serializer.rb
@@ -17,12 +17,11 @@ module V2
 
     link :self do
       url_for(controller: 'v2/repositories', action: 'show',
-              namespace_slug: object.namespace.to_param,
-              slug: object.slug)
+              slug: object.to_param)
     end
 
     def id
-      object.slug
+      object.to_param
     end
   end
 end

--- a/app/serializers/v2/repository_serializer.rb
+++ b/app/serializers/v2/repository_serializer.rb
@@ -16,8 +16,10 @@ module V2
     end
 
     link :self do
+      parts = object.to_param.split('/', 2)
       url_for(controller: 'v2/repositories', action: 'show',
-              slug: object.to_param)
+              slug: object.to_param).
+        sub(parts.join('%2F'), object.to_param)
     end
 
     def id

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 # require 'sprockets/railtie'
 # require 'rails/test_unit/railtie'
+require 'devise'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :namespaces,
     format: false,
     controller: 'v2/namespaces',
@@ -10,7 +9,15 @@ Rails.application.routes.draw do
       resources :repositories,
         format: false,
         controller: 'v2/repositories',
-        except: %i(new edit),
-        param: :slug
+        only: :index
     end
+
+  # Repositories is actually nested in namespaces, but its slug contains the
+  # namespace's slug, separated by a slash.
+  resources :repositories,
+    format: false,
+    controller: 'v2/repositories',
+    except: %i(index new edit),
+    param: :slug,
+    constraints: {slug: %r{[^/]+/[^/]+}}
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,14 @@
 #
 #  movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #  Character.create(name: 'Luke', movie: movies.first)
+
+%w(ada bob).each do |name|
+  User.new(name: name).save
+end
+
+namespace_count = Namespace.count
+%w(repo1 repo2 repo3 repo4).each_with_index do |name, index|
+  r = Repository.new(name: name, content_type: 'ontology', public_access: true)
+  r.namespace = Namespace.all[index % namespace_count]
+  r.save
+end

--- a/spec/controllers/v2/repositories_controller_spec.rb
+++ b/spec/controllers/v2/repositories_controller_spec.rb
@@ -64,11 +64,12 @@ RSpec.describe V2::RepositoriesController do
         let(:name) { 'n' }
         before do
           data = {attributes:
-                  {name: name,
+                  {namespace_id: repository.namespace.to_param,
+                   name: name,
                    description: "New #{repository.description}",
                    content_type: repository.content_type,
                    public_access: repository.public_access}}
-          post :create, params: {namespace_slug: namespace.to_param, data: data}
+          post :create, params: {data: data}
         end
         it { expect(response).to have_http_status(:unprocessable_entity) }
         it { expect(response).to match_response_schema('v2', 'jsonapi') }

--- a/spec/controllers/v2/repositories_controller_spec.rb
+++ b/spec/controllers/v2/repositories_controller_spec.rb
@@ -131,6 +131,24 @@ RSpec.describe V2::RepositoriesController do
         end
       end
     end
+
+    context 'with invalid data' do
+      let(:bad_content_type) { "Bad-#{repository.content_type}" }
+      before do
+        patch :update, params: {slug: repository.slug,
+                                data: data.
+                                  merge(attributes: data[:attributes].
+                                    merge(content_type: bad_content_type))}
+      end
+      it { expect(response).to have_http_status(:unprocessable_entity) }
+      it { expect(response).to match_response_schema('v2', 'jsonapi') }
+      it do
+        expect(response).to match_response_schema('v2', 'validation_error')
+      end
+      it 'does not create the repository' do
+        expect(Repository.find(slug: repository.slug)).to eq(repository)
+      end
+    end
   end
 
   describe 'DELETE destroy' do

--- a/spec/controllers/v2/repositories_controller_spec.rb
+++ b/spec/controllers/v2/repositories_controller_spec.rb
@@ -9,10 +9,20 @@ RSpec.describe V2::RepositoriesController do
   let(:bad_slug) { "notThere-#{repository.slug}" }
 
   describe 'GET index' do
+    let!(:another_repository) { create :repository, namespace: namespace }
+    let!(:other_namespace) { create :namespace }
+    let!(:other_repository) { create :repository, namespace: other_namespace }
+
     before { get :index, params: {namespace_slug: namespace.to_param} }
+
     it { expect(response).to have_http_status(:ok) }
     it { expect(response).to match_response_schema('v2', 'jsonapi') }
     it { expect(response).to match_response_schema('v2', 'repository_index') }
+
+    it 'returns only repositories from the requested namespace' do
+      expect(JSON.parse(response.body)['data'].size).
+        to eq(namespace.repositories.count)
+    end
   end
 
   describe 'GET show' do

--- a/spec/support/api/v2/schemas/repository_data_object.json
+++ b/spec/support/api/v2/schemas/repository_data_object.json
@@ -15,7 +15,10 @@
           "type": "object",
           "required": ["self"],
           "properties": {
-            "self": {"type": "uri"}
+            "self": {
+              "type": "uri",
+              "pattern": "/[A-Za-z0-9_\-]+/[A-Za-z0-9_\-]+$"
+            }
           }
         },
         "attributes": {

--- a/spec/support/api/v2/schemas/repository_relationship_object.json
+++ b/spec/support/api/v2/schemas/repository_relationship_object.json
@@ -13,7 +13,10 @@
           "type": "object",
           "required": ["related"],
           "properties": {
-            "related": {"type": "uri"}
+            "related": {
+              "type": "uri",
+              "pattern": "/[A-Za-z0-9_\-]+/[A-Za-z0-9_\-]+$"
+            }
           }
         }
       }


### PR DESCRIPTION
This shall fix #21.
It also changes the routes to avoid doubled namespace slug in the repository URL.
Furthermore, it adds a test for a failing update due to failing validations and it adds seeds.