### PR TITLE
Fix deployment problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'pry', '~> 0.10.4'
 gem 'pry-rescue', '~> 1.4.4'
 gem 'pry-stack_explorer', '~> 0.4.9.2'
 gem 'pry-byebug', '~> 3.4.0'
-gem 'pry-coolline', '~> 0.2.5'
 gem 'pry-rails', '~> 0.3.4'
 gem 'awesome_print', '~> 1.7.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: c6946a3d9b35b31d33d2b3a02628bd4217e98e40
+  revision: 4d0a9a232c3bc712b5554f23563656bb8f81e100
   branch: master
   specs:
     ontohub-models (0.1.0)
@@ -9,7 +9,6 @@ GIT
       devise (~> 4.2.0)
       pry (~> 0.10.4)
       pry-byebug (~> 3.4.0)
-      pry-coolline (~> 0.2.5)
       pry-rescue (~> 1.4.4)
       pry-stack_explorer (~> 0.4.9.2)
       rails (~> 5.0.0, >= 5.0.0.1)
@@ -76,8 +75,6 @@ GEM
       elasticsearch (>= 1.0.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
-    coolline (0.5.0)
-      unicode_utils (~> 1.4)
     coveralls (0.8.15)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
@@ -94,12 +91,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    elasticsearch (2.0.0)
-      elasticsearch-api (= 2.0.0)
-      elasticsearch-transport (= 2.0.0)
-    elasticsearch-api (2.0.0)
+    elasticsearch (5.0.0)
+      elasticsearch-api (= 5.0.0)
+      elasticsearch-transport (= 5.0.0)
+    elasticsearch-api (5.0.0)
       multi_json
-    elasticsearch-transport (2.0.0)
+    elasticsearch-transport (5.0.0)
       faraday
       multi_json
     erubis (2.7.0)
@@ -110,7 +107,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.6)
       i18n (~> 0.5)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     globalid (0.3.7)
@@ -156,8 +153,6 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    pry-coolline (0.2.5)
-      coolline (~> 0.5)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     pry-rescue (1.4.4)
@@ -258,7 +253,6 @@ GEM
     tins (1.12.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode_utils (1.4.0)
     warden (1.2.6)
       rack (>= 1.0)
     websocket-driver (0.6.4)
@@ -280,7 +274,6 @@ DEPENDENCIES
   ontohub-models!
   pry (~> 0.10.4)
   pry-byebug (~> 3.4.0)
-  pry-coolline (~> 0.2.5)
   pry-rails (~> 0.3.4)
   pry-rescue (~> 1.4.4)
   pry-stack_explorer (~> 0.4.9.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This class is not actually used, but needed for loading the application in the
+# production environment
+class ApplicationController < ActionController::API
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum, this matches the default thread size of Active Record.
+# Specifies the `environment` that Puma will run in.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i
-threads threads_count, threads_count
+@environment = ENV.fetch('RAILS_ENV') { 'development' }
+environment @environment
+def production?
+  @environment == 'production'
+end
 
 # Specifies the `port` that Puma will listen on to receive requests, default is
 # 3000.
 #
 port ENV.fetch('PORT') { 3000 }
 
-# Specifies the `environment` that Puma will run in.
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum, this matches the default thread size of Active Record.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { production? ? 1 : 5 }.to_i
+threads threads_count, threads_count
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -24,7 +28,11 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch('WEB_CONCURRENCY') { 2 }
+workers ENV.fetch('WEB_CONCURRENCY') { 24 }.to_i if production?
+
+# Disable request logging.
+# The default is "false".
+quiet if production?
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -33,7 +41,7 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app! if production?
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -41,10 +49,27 @@ environment ENV.fetch('RAILS_ENV') { 'development' }
 # option you will want to use this block to reconnect to any threads
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
-#
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+if production?
+  on_worker_boot do
+    # let's make sure, that users with the same GID as the running puma process
+    # are really able to control puma (the group needs write access). See option
+    # --control and --control-url above.
+    if @options[:control_url]
+      uri = URI.parse(@options[:control_url])
+      FileUtils.chmod(0o770, uri.path) if uri.scheme == 'unix'
+    end
+    # Load the models
+    ::SequelRails.setup @environment
+  end
+end
+
+# Code to run immediately before the master starts workers:
+# Disconnect from the database before creating a worker.
+if production?
+  before_fork do
+    ::Sequel::Model.db.disconnect
+  end
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
This fixes problems of the deployment and issues a `bundle update`.

* The gem `pry-coolline` is removed (see https://github.com/ontohub/ontohub-models/pull/24).
* The puma config is adjusted to the server's needs.
* An `ApplicationController` is added. It doesn't do a single thing, but it needs to exist because otherwise, the Rails application can't load in the production environment.

#### Todo
* [x] Update the branch of `ontohub-models` to `master` when https://github.com/ontohub/ontohub-models/pull/24 is merged