### PR TITLE
20 create dummy search controller

### DIFF
--- a/app/controllers/v2/search_controller.rb
+++ b/app/controllers/v2/search_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V2
+  # The SearchController presents the search result
+  class SearchController < ApplicationController
+    def search
+      render status: :ok,
+             json: resource,
+             serializer: V2::SearchResultSerializer
+    end
+
+    protected
+
+    def resource
+      @resource ||= SearchResult.new(params)
+    end
+  end
+end

--- a/app/controllers/v2/users_controller.rb
+++ b/app/controllers/v2/users_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module V2
+  # Handles user show requests
+  class UsersController < ResourcesController
+    find_param :slug
+    actions :show
+  end
+end

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# The SearchResult is a non-persistant object that groups models that can be
+# searched.
+class SearchResult < ActiveModelSerializers::Model
+  attr_accessor :repositories, :users,
+                :results_count, :repositories_count, :users_count
+
+  def initialize(_params)
+    repositories = Repository.all
+    users = User.all
+    repositories_count = repositories.count
+    users_count = users.count
+    super(repositories: repositories,
+          users: users,
+          repositories_count: repositories_count,
+          users_count: users_count,
+          results_count: [repositories_count, users_count].sum)
+  end
+end

--- a/app/serializers/v2/namespace_serializer.rb
+++ b/app/serializers/v2/namespace_serializer.rb
@@ -3,6 +3,13 @@
 module V2
   # The serializer for Repositories, API version 2
   class NamespaceSerializer < ApplicationSerializer
+    # The serializer for the relationship object
+    class Relationship < ApplicationSerializer
+      def id
+        object.to_param
+      end
+    end
+
     attribute :name
 
     link :self do
@@ -11,7 +18,8 @@ module V2
       [Settings.server_url, path].join('/')
     end
 
-    has_many :repositories do
+    has_many :repositories,
+      serializer: V2::RepositorySerializer::Relationship do
       include_data false
       link :related do
         path = url_for(controller: 'v2/repositories', action: 'index',

--- a/app/serializers/v2/repository_serializer.rb
+++ b/app/serializers/v2/repository_serializer.rb
@@ -3,12 +3,19 @@
 module V2
   # The serializer for Repositories, API version 2
   class RepositorySerializer < ApplicationSerializer
+    # The serializer for the relationship object
+    class Relationship < ApplicationSerializer
+      def id
+        object.to_param
+      end
+    end
+
     attribute :name
     attribute :description
     attribute :content_type
     attribute :public_access
 
-    has_one :namespace, serializer: V2::NamespaceSerializer do
+    has_one :namespace, serializer: V2::NamespaceSerializer::Relationship do
       link :related do
         path = url_for(controller: 'v2/namespaces', action: 'show',
                        slug: object.namespace.to_param, only_path: true)

--- a/app/serializers/v2/search_result_serializer.rb
+++ b/app/serializers/v2/search_result_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module V2
+  # The serializer for the SearchResult, API version 2
+  class SearchResultSerializer < ApplicationSerializer
+    attributes :id, :results_count, :repositories_count, :users_count
+    delegate :id, :results_count, :repositories_count, :users_count, to: :object
+
+    has_many(:repositories)
+    has_many(:users)
+  end
+end

--- a/app/serializers/v2/search_result_serializer.rb
+++ b/app/serializers/v2/search_result_serializer.rb
@@ -6,7 +6,7 @@ module V2
     attributes :id, :results_count, :repositories_count, :users_count
     delegate :id, :results_count, :repositories_count, :users_count, to: :object
 
-    has_many(:repositories)
-    has_many(:users)
+    has_many(:repositories, serializer: V2::RepositorySerializer::Relationship)
+    has_many(:users, serializer: V2::UserSerializer::Relationship)
   end
 end

--- a/app/serializers/v2/user_serializer.rb
+++ b/app/serializers/v2/user_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V2
+  # The serializer for Users, API version 2
+  class UserSerializer < ApplicationSerializer
+    attribute :name
+    attribute :display_name
+    attribute :email
+
+    def id
+      object.slug
+    end
+
+    link :self do
+      url_for(controller: 'v2/users', action: :show, slug: object.to_param)
+    end
+
+    # This needs to be implemented properly when the teams are implemented
+    has_many(:teams) do
+      []
+    end
+  end
+end

--- a/app/serializers/v2/user_serializer.rb
+++ b/app/serializers/v2/user_serializer.rb
@@ -3,12 +3,19 @@
 module V2
   # The serializer for Users, API version 2
   class UserSerializer < ApplicationSerializer
+    # The serializer for the relationship object
+    class Relationship < ApplicationSerializer
+      def id
+        object.to_param
+      end
+    end
+
     attribute :name
     attribute :display_name
     attribute :email
 
     def id
-      object.slug
+      object.to_param
     end
 
     link :self do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@
 
 Rails.application.routes.draw do
   scope format: false do
+    resources :users,
+      controller: 'v2/users',
+      only: :show,
+      param: :slug
+
     resources :namespaces,
       controller: 'v2/namespaces',
       only: :show,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,23 +1,22 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :namespaces,
-    format: false,
-    controller: 'v2/namespaces',
-    only: :show,
-    param: :slug do
-      resources :repositories,
-        format: false,
-        controller: 'v2/repositories',
-        only: :index
-    end
+  scope format: false do
+    resources :namespaces,
+      controller: 'v2/namespaces',
+      only: :show,
+      param: :slug do
+        resources :repositories,
+          controller: 'v2/repositories',
+          only: :index
+      end
 
-  # Repositories is actually nested in namespaces, but its slug contains the
-  # namespace's slug, separated by a slash.
-  resources :repositories,
-    format: false,
-    controller: 'v2/repositories',
-    except: %i(index new edit),
-    param: :slug,
-    constraints: {slug: %r{[^/]+/[^/]+}}
+    # Repositories is actually nested in namespaces, but its slug contains the
+    # namespace's slug, separated by a slash.
+    resources :repositories,
+      controller: 'v2/repositories',
+      except: %i(index new edit),
+      param: :slug,
+      constraints: {slug: %r{[^/]+/[^/]+}}
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,7 @@ Rails.application.routes.draw do
       except: %i(index new edit),
       param: :slug,
       constraints: {slug: %r{[^/]+/[^/]+}}
+
+    get 'search', controller: 'v2/search', action: 'search'
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,8 +15,12 @@
 end
 
 namespace_count = Namespace.count
+content_types = %w(ontology model specification)
 %w(repo1 repo2 repo3 repo4).each_with_index do |name, index|
-  r = Repository.new(name: name, content_type: 'ontology', public_access: true)
+  r = Repository.new(name: name,
+                     content_type: content_types[index % content_types.size],
+                     public_access: true,
+                     description: 'This is a dummy repository.')
   r.namespace = Namespace.all[index % namespace_count]
   r.save
 end

--- a/spec/controllers/v2/search_controller_spec.rb
+++ b/spec/controllers/v2/search_controller_spec.rb
@@ -3,12 +3,48 @@
 require 'rails_helper'
 
 RSpec.describe V2::SearchController do
+  let(:num_objects) { 2 }
+  before do
+    num_objects.times { create :user }
+    User.each { |user| create :repository, namespace: user.namespace }
+  end
+
   describe 'GET search' do
     context 'successful' do
       before { get :search }
       it { expect(response).to have_http_status(:ok) }
       it { expect(response).to match_response_schema('v2', 'jsonapi') }
       it { expect(response).to match_response_schema('v2', 'search_search') }
+
+      it 'presents the correct results_count' do
+        json = JSON.parse(response.body)
+        expect(json['data']['attributes']['results_count']).
+          to eq(2 * num_objects)
+      end
+
+      it 'presents the correct repositories_count' do
+        json = JSON.parse(response.body)
+        expect(json['data']['attributes']['repositories_count']).
+          to eq(num_objects)
+      end
+
+      it 'presents the correct users_count' do
+        json = JSON.parse(response.body)
+        expect(json['data']['attributes']['users_count']).
+          to eq(num_objects)
+      end
+
+      it 'lists the correct number of repositories' do
+        json = JSON.parse(response.body)
+        expect(json['data']['relationships']['repositories']['data'].size).
+          to eq(num_objects)
+      end
+
+      it 'lists the correct number of users' do
+        json = JSON.parse(response.body)
+        expect(json['data']['relationships']['users']['data'].size).
+          to eq(num_objects)
+      end
     end
   end
 end

--- a/spec/controllers/v2/search_controller_spec.rb
+++ b/spec/controllers/v2/search_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::SearchController do
+  describe 'GET search' do
+    context 'successful' do
+      before { get :search }
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to match_response_schema('v2', 'jsonapi') }
+      it { expect(response).to match_response_schema('v2', 'search_search') }
+    end
+  end
+end

--- a/spec/controllers/v2/users_controller_spec.rb
+++ b/spec/controllers/v2/users_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::UsersController do
+  subject { create :user }
+  let(:bad_slug) { "notThere-#{subject.slug}" }
+
+  describe 'GET show' do
+    context 'successful' do
+      before { get :show, params: {slug: subject.slug} }
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to match_response_schema('v2', 'jsonapi') }
+      it { expect(response).to match_response_schema('v2', 'user_show') }
+    end
+
+    context 'failing with an inexistent URL' do
+      before { get :show, params: {slug: bad_slug} }
+      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response.body.strip).to be_empty }
+    end
+  end
+end

--- a/spec/support/api/v2/schemas/search_data_object.json
+++ b/spec/support/api/v2/schemas/search_data_object.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "search_data_object.json",
+  "title": "Search Data Object",
+  "description": "This is a schema for the Search data object.",
+
+  "definitions": {
+    "search": {
+      "type": "object",
+      "required": ["id", "type", "attributes", "relationships"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^searchresult$"
+        },
+        "type": {"type": "string"},
+        "attributes": {
+          "type": "object",
+          "required": ["results_count", "repositories_count", "users_count"],
+          "properties": {
+            "results_count": {"type": "integer"},
+            "repositories_count": {"type": "integer"},
+            "users_count": {"type": "integer"}
+          }
+        },
+        "relationships": {
+          "type": "object",
+          "required": ["repositories", "users"],
+          "properties": {
+            "repositories": {
+              "type": "object",
+              "required": ["data"],
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["id", "type"],
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9_\-]+/[A-Za-z0-9_\-]+$"
+                      },
+                      "type": {
+                        "type": "string",
+                        "pattern": "^repositories$"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "users": {
+              "type": "object",
+              "required": ["data"],
+              "properties": {
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["id", "type"],
+                    "properties": {
+                      "id": {"type": "string"},
+                      "type": {
+                        "type": "string",
+                        "pattern": "^users$"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/api/v2/schemas/search_search.json
+++ b/spec/support/api/v2/schemas/search_search.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "search_search.json",
+  "title": "Search Search Schema",
+  "description": "This is a schema for the search action of the SearchController.",
+
+  "type": "object",
+  "required": ["data", "jsonapi"],
+  "properties": {
+    "data": {
+      "$ref": "search_data_object.json#definitions/search"
+    },
+    "jsonapi": { "$ref": "jsonapi_toplevel_object.json#definitions/jsonapi" }
+  }
+}

--- a/spec/support/api/v2/schemas/team_relationship_object.json
+++ b/spec/support/api/v2/schemas/team_relationship_object.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "team_relationship_object.json",
+  "title": "Team Relationship Object",
+  "description": "This is a schema for the Team relationship object.",
+
+  "definitions": {
+    "team": {}
+  }
+}

--- a/spec/support/api/v2/schemas/user_data_object.json
+++ b/spec/support/api/v2/schemas/user_data_object.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "user_data_object.json",
+  "title": "User Data Object",
+  "description": "This is a schema for the Repository data object.",
+
+  "definitions": {
+    "user": {
+      "type": "object",
+      "required": ["id", "type", "links", "attributes", "relationships"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"type": "string"},
+        "links": {
+          "type": "object",
+          "required": ["self"],
+          "properties": {
+            "self": {"type": "uri"}
+          }
+        },
+        "attributes": {
+          "type": "object",
+          "required": ["name", "display_name", "email"],
+          "properties": {
+            "name": {"type": "string"},
+            "display_name": {"type": "string"},
+            "email": {
+              "type": "string",
+              "pattern": "[^@]+@[^@]+"
+            }
+          }
+        },
+        "relationships": {
+          "type": "object",
+          "required": ["teams"],
+          "properties": {
+            "teams": {
+              "$ref": "team_relationship_object.json#definitions/team"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/api/v2/schemas/user_show.json
+++ b/spec/support/api/v2/schemas/user_show.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "user_show.json",
+  "title": "User Show Schema",
+  "description": "This is a schema for the show action of the UsersController.",
+
+  "type": "object",
+  "required": ["data", "jsonapi"],
+  "properties": {
+    "data": {
+      "$ref": "user_data_object.json#definitions/user"
+    },
+    "jsonapi": { "$ref": "jsonapi_toplevel_object.json#definitions/jsonapi" }
+  }
+}


### PR DESCRIPTION
This shall fix #20. The output of `http -j :3000/search` looks like this:

```json
{
    "data": {
        "attributes": {
            "repositories_count": 4,
            "results_count": 6,
            "users_count": 2
        },
        "id": "searchresult",
        "relationships": {
            "repositories": {
                "data": [
                    {
                        "id": "ada/repo1",
                        "type": "repositories"
                    },
                    {
                        "id": "bob/repo2",
                        "type": "repositories"
                    },
                    {
                        "id": "ada/repo3",
                        "type": "repositories"
                    },
                    {
                        "id": "bob/repo4",
                        "type": "repositories"
                    }
                ]
            },
            "users": {
                "data": [
                    {
                        "id": "ada",
                        "type": "users"
                    },
                    {
                        "id": "bob",
                        "type": "users"
                    }
                ]
            }
        },
        "type": "search_results"
    },
    "jsonapi": {
        "version": "1.0"
    }
}
```

And the output of `http -j :3000/users/ada` looks like this
```json
{
    "data": {
        "attributes": {
            "display_name": null,
            "email": null,
            "name": "ada"
        },
        "id": "ada",
        "links": {
            "self": "http://localhost:3000/users/ada"
        },
        "relationships": {
            "teams": {
                "data": []
            }
        },
        "type": "users"
    },
    "jsonapi": {
        "version": "1.0"
    }
}
```