### PR TITLE
37 add short routes for namespace and repository

### DIFF
--- a/app/controllers/v2/organizational_units_controller.rb
+++ b/app/controllers/v2/organizational_units_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module V2
+  # Handles user show requests
+  class OrganizationalUnitsController < ReroutingController
+    def show
+      send_controller_action(:show,
+                             OrganizationalUnit.find(slug: params[:slug]))
+    end
+  end
+end

--- a/app/controllers/v2/rerouting_controller.rb
+++ b/app/controllers/v2/rerouting_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module V2
+  # This controller is the base class for controllers that need to re-route a
+  # request to the action of another controller.
+  class ReroutingController < ApplicationController
+    protected
+
+    def send_controller_action(action, resource)
+      @resource = resource
+      @other_controller = controller_class(resource).new
+      define_state
+      remap_params(action)
+      @other_controller.send(action)
+      self.response_body = @other_controller.response_body
+    end
+
+    private
+
+    def controller_class(resource)
+      "V2::#{resource.class.to_s.pluralize}Controller".constantize
+    end
+
+    def define_state
+      @other_controller.instance_variable_set(:@resource,
+                                              instance_variable_get(:@resource))
+      @other_controller.request = request
+      @other_controller.response = response
+    end
+
+    def remap_params(action)
+      params['controller'] = @other_controller.controller_path
+      params['action'] = action.to_s
+      rename_model_based_params_key
+      @other_controller.instance_variable_set(:@_params, params)
+    end
+
+    def model_based_params_key(controller)
+      controller.class.to_s.sub(/\AV2::/, '').sub(/Controller\z/, '').
+        underscore.singularize
+    end
+
+    def rename_model_based_params_key
+      current_key = model_based_params_key(self)
+      target_key = model_based_params_key(@other_controller)
+      params[target_key] = params.delete(current_key).to_h
+    end
+  end
+end

--- a/app/controllers/v2/resources_controller.rb
+++ b/app/controllers/v2/resources_controller.rb
@@ -19,8 +19,8 @@ module V2
   # access to the requested data.
   class ResourcesController < ApplicationController
     # Simplify calling of resource and collection
-    include ResourcesHelpers::InstanceMethods
-    extend ResourcesHelpers::ClassMethods
+    include DSL::InstanceMethods
+    extend DSL::ClassMethods
 
     def self.inherited(subclass)
       subclass.infer_resource_class

--- a/app/controllers/v2/resources_controller/dsl.rb
+++ b/app/controllers/v2/resources_controller/dsl.rb
@@ -3,7 +3,7 @@
 module V2
   class ResourcesController
     # Defines methods for detecting the resource class
-    module ResourcesHelpers
+    module DSL
       # Instance methods to use in a controller
       module InstanceMethods
         def collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
   scope format: false do
@@ -30,5 +31,10 @@ Rails.application.routes.draw do
 
     get 'search', controller: 'v2/search', action: 'search'
     get 'version', controller: 'v2/version', action: 'show'
+
+    get '/:slug',
+      controller: 'v2/organizational_units',
+      action: :show,
+      as: :organizational_unit
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,12 @@ Rails.application.routes.draw do
     get 'search', controller: 'v2/search', action: 'search'
     get 'version', controller: 'v2/version', action: 'show'
 
+    scope '/organizational_units' do
+      get '/:slug',
+        controller: 'v2/organizational_units',
+        action: :show
+    end
+
     get '/:slug',
       controller: 'v2/organizational_units',
       action: :show,

--- a/doc/api/organizational_units.md
+++ b/doc/api/organizational_units.md
@@ -1,0 +1,17 @@
+# OrganizationalUnits
+
+An OrganizatinoalUnit is either a [User](users.md) or an [Organization](organizations.md).
+
+## Actions
+### Read
+###### Route
+    GET /:user_or_organization_id
+###### Example Command
+    $ http -j :3000/ada
+###### Description
+Lists all information on the user or organization with the ID `ada`.
+
+#### Response Data
+* 200/OK: Contains
+  * the [User Resource Object](users.md#resource-object) if `ada` is a user or
+  * the [Organization Resource Object](organizations.md#resource-object) if `ada` is an organization.

--- a/spec/controllers/v2/organizational_units_controller_spec.rb
+++ b/spec/controllers/v2/organizational_units_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V2::OrganizationalUnitsController do
+  let!(:user) { create :user }
+  let!(:organization) { create :organization }
+
+  before do
+    organization.add_member(user)
+    organization.add_member(create(:user))
+  end
+
+  context 'subject: user' do
+    subject { user }
+
+    describe 'GET show' do
+      context 'successful' do
+        before { get :show, params: {slug: subject.slug} }
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response).to match_response_schema('v2', 'jsonapi') }
+        it { expect(response).to match_response_schema('v2', 'user_show') }
+      end
+    end
+  end
+
+  context 'subject: organization' do
+    subject { organization }
+
+    describe 'GET show' do
+      context 'successful' do
+        before { get :show, params: {slug: subject.slug} }
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response).to match_response_schema('v2', 'jsonapi') }
+        it do
+          expect(response).to match_response_schema('v2', 'organization_show')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This shall fix #37. This is based on #43. The first new commit is "Rename module to DSL. ea0f19c"

It first checks of which class the requested object is and then instantiates the corresponding controller to call the corresponding actions. The params must be changed to allow the target controller to work properly.

Todo:
* [ ] Rebase on master as soon as #43 is merged.