### PR TITLE
Use User#to_param as user id.

### DIFF
--- a/app/controllers/v2/users/sessions_controller.rb
+++ b/app/controllers/v2/users/sessions_controller.rb
@@ -18,7 +18,7 @@ module V2
       protected
 
       def generate_token
-        payload = {user_id: current_user.id}
+        payload = {user_id: current_user.to_param}
         AuthenticationToken.new(token: JWTWrapper.encode(payload))
       end
     end

--- a/config/initializers/core_extensions/devise/strategies/json_web_token.rb
+++ b/config/initializers/core_extensions/devise/strategies/json_web_token.rb
@@ -14,7 +14,7 @@ module Devise
       def authenticate!
         return fail! unless claims&.key?('user_id')
 
-        success! User.find(users__id: claims['user_id'])
+        success! User.find(organizational_units__slug: claims['user_id'])
       end
 
       protected


### PR DESCRIPTION
This shall fix an issue with Ember/JWT/Backend interaction. Instead of the numerical user id, we need to pass the user param (slug).

We should test this in #46.