### PR TITLE
Use gitlab_git master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'ontohub-models', github: 'ontohub/ontohub-models',
                       branch: 'master'
 
 gem 'gitlab_git', github: 'ontohub/gitlab_git',
-                  branch: 'update_to_9.0.5'
+                  branch: 'master'
 
 gem 'active_model_serializers', '~> 0.10.4'
 gem 'config', '~> 1.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/ontohub/gitlab_git.git
-  revision: f242d68f674400c5475980a6919b4e2cc7f75f49
-  branch: update_to_9.0.5
+  revision: 6f0c6f0afb65fc69e688865a51e70b1b68bf4c76
+  branch: master
   specs:
     gitlab_git (10.7.0)
       activesupport (>= 4.0)


### PR DESCRIPTION
The `gitlab_git` repo has been updated, so we can use the master branch again. See https://github.com/ontohub/gitlab_git/pull/1#issuecomment-298007180