### PR TITLE
Upgrade Rubinius to 3.77.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 
 rvm:
   - 2.4.1
-  - rbx-3.73
+  - rbx-3.77
 
 services:
   - postgresql

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 7263c41b474abf7df297b602649ef6fb3b5886e7
+  revision: 8011fa32aa9eb685afd9afcb6ea50903dde13cf8
   branch: master
   specs:
     ontohub-models (0.1.0)
@@ -124,7 +124,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
-    faraday (0.12.0.1)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     github-linguist (4.7.6)
@@ -147,7 +147,7 @@ GEM
       ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
+    mail (2.6.5)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (3.1)
@@ -183,7 +183,7 @@ GEM
       pry (>= 0.9.11)
     public_suffix (2.0.5)
     puma (3.8.2)
-    rack (2.0.1)
+    rack (2.0.2)
     rack-cors (0.4.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -214,8 +214,9 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
-    responders (2.3.0)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -248,7 +249,7 @@ GEM
       activemodel
       railties (>= 3.2.0)
       sequel (>= 3.28, < 5.0)
-    sequel_pg (1.6.17)
+    sequel_pg (1.6.18)
       pg (>= 0.8.0)
       sequel (>= 4.0.0)
     simplecov (0.14.1)

--- a/app/controllers/v2/trees_controller.rb
+++ b/app/controllers/v2/trees_controller.rb
@@ -72,12 +72,7 @@ module V2
       @resource ||= Blob.find(repository_id: repository.to_param,
                               branch: ref,
                               path: params[:path])
-      # Use @resource&.user = current_user as soon as
-      # https://github.com/rubinius/rubinius/issues/3739
-      # is fixed.
-      # rubocop:disable Style/SafeNavigation
-      @resource.user = current_user unless @resource.nil?
-      # rubocop:enable Style/SafeNavigation
+      @resource&.user = current_user
       @resource
     end
 


### PR DESCRIPTION
From version 3.77 on, Rubinius supports safe navigation for setters. Our code is changed accordingly.