### PR TITLE
Minor code improvements

### DIFF
--- a/app/helpers/jwt_wrapper.rb
+++ b/app/helpers/jwt_wrapper.rb
@@ -4,17 +4,27 @@
 module JWTWrapper
   extend module_function
 
+  # :nocov:
+  # This is only used before the application starts to set up the keys
   def generate_private_key
     key = OpenSSL::PKey::EC.new('prime256v1')
     key.generate_key
   end
-  PRIVATE_KEY = OpenSSL::PKey::EC.new(Rails.application.secrets.jwt[:private])
 
   def generate_public_key(private_key)
     key = OpenSSL::PKey::EC.new(private_key)
     key.private_key = nil
     key
   end
+
+  def generate_key_pair
+    private_key = generate_private_key
+    public_key = generate_public_key(private_key)
+    {public: public_key, private: private_key}
+  end
+  # :nocov:
+
+  PRIVATE_KEY = OpenSSL::PKey::EC.new(Rails.application.secrets.jwt[:private])
   PUBLIC_KEY = OpenSSL::PKey::EC.new(Rails.application.secrets.jwt[:public])
 
   def encode(payload, expiration = nil)

--- a/lib/tasks/apidoc.rake
+++ b/lib/tasks/apidoc.rake
@@ -25,8 +25,17 @@ namespace :apidoc do
 
   desc "Run the API documentation server on port ENV['PORT'] (requires yarn)."
   task :run do
-    Dir.chdir(APIDOC_DIR) do
-      system('yarn', 'start')
+    pid = Kernel.fork do
+      Dir.chdir(APIDOC_DIR) do
+        Kernel.exec('yarn', 'start')
+      end
     end
+    %w(INT TERM).each do |signal|
+      Signal.trap(signal) do
+        Process.kill(signal, pid)
+        exit
+      end
+    end
+    sleep
   end
 end

--- a/lib/tasks/secret.rake
+++ b/lib/tasks/secret.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+namespace :secret do
+  desc 'Print out a key pair for JWT'
+  task jwt: :environment do
+    key_pair = JWTWrapper.generate_key_pair
+
+    %i(public private).each do |type|
+      $stdout.puts("#{type} key between the two lines:")
+      $stdout.puts('#' * 80)
+      $stdout.puts(key_pair[type].to_pem)
+      $stdout.puts('#' * 80)
+      $stdout.puts
+    end
+  end
+end


### PR DESCRIPTION
This improves some code slightly. It
* puts code into `:nocov:` that belongs there
* adds a task to easily generate a JWT key pair for the config (in case we need to generate a new pair in the future)
* shuts down the apidoc server gracefully such that no backtrace is printed for a <kbd>Ctrl</kbd>+<kbd>C</kbd>