### PR TITLE
Conditionally add Codecov formatter

### DIFF
--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -11,9 +11,8 @@ if RUBY_ENGINE == 'ruby' # not 'rbx'
       add_filter 'config/initializers/config.rb'
     end
     require 'codecov'
-    SimpleCov.formatters = [
-      SimpleCov::Formatter::HTMLFormatter,
-      SimpleCov::Formatter::Codecov
-    ]
+    formatters = [SimpleCov::Formatter::HTMLFormatter]
+    formatters << SimpleCov::Formatter::Codecov if ENV['CI']
+    SimpleCov.formatters = formatters
   end
 end


### PR DESCRIPTION
This gets rid of the
```
{"error": {"context": null, "reason": "Please provide the repository token to upload reports via `-t :repository-token`"}, "meta": {"status": 400}}
```
warning we get when locally running rspec by disabling Codecov unless it's run in a CI environment.