### PR TITLE
Fix recaptcha config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'pry-rescue', '~> 1.4.4', platform: :mri
 gem 'pry-stack_explorer', '~> 0.4.9.2', platform: :mri
 
 gem 'jwt', '~> 1.5.6'
-gem 'recaptcha', '~> 4.1.0'
+gem 'recaptcha', '~> 4.3.1'
 gem 'graphql', '~> 1.6.3'
 gem 'graphql-batch', '~> 0.3.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: f76522c75526d98f238106b20b12840c0b6faf5b
+  revision: 95d9df93bc7f7ba60171ef45ef321c505c7605f1
   branch: master
   specs:
     ontohub-models (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    recaptcha (4.1.0)
+    recaptcha (4.3.1)
       json
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -316,7 +316,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rack-cors
   rails (~> 5.1.2)
-  recaptcha (~> 4.1.0)
+  recaptcha (~> 4.3.1)
   rspec (~> 3.6.0)
   rspec-rails (~> 3.6.0)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ontohub/gitlab_git.git
-  revision: 231a1a847ef7746dbacaee533b96fab96084dc0f
+  revision: fd53844f3351d4448211399099b54a9a8fd55e1a
   branch: master
   specs:
     gitlab_git (11.0.0)

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Recaptcha.configure do |config|
-  config.site_key = Rails.application.secrets.recaptcha['site_key']
-  config.secret_key = Rails.application.secrets.recaptcha['secret_key']
+  config.site_key = Rails.application.secrets.recaptcha[:site_key]
+  config.secret_key = Rails.application.secrets.recaptcha[:secret_key]
   # Uncomment the following line if you are using a proxy server:
   # config.proxy = 'http://myproxy.com.au:8080'
 end


### PR DESCRIPTION
The parser of the secrets.yml saves the data in symbol-keys since Rails 5.1 and not string-keys anymore. This fixes it along with some gem updates.