### PR TITLE
Enable fast_finish on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - rbx-3.82
 
 matrix:
+  fast_finish: true
   allow_failures:
   - rvm: rbx-3.82
 


### PR DESCRIPTION
This makes Travis not wait for builds that are allowed to fail before reporting the build status to Github, which should improve our feedback duration [bigly](http://memeshappen.com/media/created/2016/12/-Thats-bigly-yuuuge.jpg).