### PR TITLE
Add task to generate GraphQL schema JSON.

### DIFF
--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -6,4 +6,12 @@ namespace :graphql do
     generated = GraphQL::Schema::Printer.print_schema(OntohubBackendSchema)
     File.write(Rails.root.join('spec/support/schema.graphql'), "#{generated}\n")
   end
+
+  desc 'Write the GraphQL schema json file to FILE=graphql_schema.json'
+  task write_json: :environment do
+    output_file = ENV['FILE'] || 'graphql_schema.json'
+    schema_hash = OntohubBackendSchema.
+      execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+    File.write(output_file, schema_hash.to_json)
+  end
 end


### PR DESCRIPTION
This is needed to generate the documentation HTML of the GraphQL API with the gem [graphql-docs](https://github.com/eugenk/graphql-docs/tree/improve_style_and_fix_nil_fields).