### PR TITLE
Fix account creation.

### DIFF
--- a/app/helpers/account_methods.rb
+++ b/app/helpers/account_methods.rb
@@ -12,6 +12,7 @@ module AccountMethods
   def build_resource(hash = nil)
     self.resource = User.new_with_session(hash || {}, session)
     resource.url_path_method = ModelURLPath.user
+    resource.role ||= 'user'
     resource.valid?
     return if DISABLE_CAPTCHA || captcha_ok?
     # +captcha_ok?+ is always +true+ in the test environment


### PR DESCRIPTION
The test suite failed with
```
  1) signUp mutation unsuccessful name is not available returns an error
     Failure/Error:
       expect(subject['errors']).
         to include(include('message' => 'name is already taken'))

       expected [{"message" => "role is not in range or set: [\"admin\", \"user\"], name is already taken", "locations" => [{"line" => 2, "column" => 7}], "path" => ["signUp"]}] to include (include {"message" => "name is already taken"})
       Diff:
       @@ -1,2 +1,5 @@
       -[(include {"message" => "name is already taken"})]
       +[{"message"=>
       +   "role is not in range or set: [\"admin\", \"user\"], name is already taken",
       +  "locations"=>[{"line"=>2, "column"=>7}],
       +  "path"=>["signUp"]}]

     # ./spec/graphql/mutations/account/sign_up_mutation_spec.rb:95:in `block (4 levels) in <top (required)>'
```
on master. This fixes the issue.