### PR TITLE
Split validation errors

### DIFF
--- a/app/graphql/instrumenters/validation_error_instrumenter.rb
+++ b/app/graphql/instrumenters/validation_error_instrumenter.rb
@@ -4,14 +4,23 @@ module Instrumenters
   # Rescues Sequel::ValidationFailed errors and raises
   # GraphQL::ExecutionError instead
   class ValidationErrorInstrumenter
+    # rubocop:disable Metrics/MethodLength
     def instrument(_type, field)
+      # rubocop:enable Metrics/MethodLength
       old_resolve = field.resolve_proc
       field.redefine do
         resolve(lambda do |root, arguments, context|
           begin
             old_resolve.call(root, arguments, context)
           rescue Sequel::ValidationFailed => error
-            context.add_error(GraphQL::ExecutionError.new(error.message))
+            error.errors.each do |field_name, errors|
+              errors.each do |message|
+                context.add_error(
+                  GraphQL::ExecutionError.new("#{field_name} #{message}")
+                )
+              end
+            end
+            nil
           end
         end)
       end


### PR DESCRIPTION
At the moment, validation errors will be concatenated to one long string; this PR returns each validation error as a single `errors` entry, which makes it easier to display them in the frontend.