### PR TITLE
Fix skip arguments and improve default argument handling in tests

### DIFF
--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -23,9 +23,8 @@ Types::OrganizationType = GraphQL::ObjectType.define do
     end
 
     resolve(lambda do |organization, arguments, _context|
-      limit = arguments[:limit] || target.arguments['limit'].default_value
-      skip = arguments[:skip] || target.arguments['skip'].default_value
-      organization.members_dataset.limit(limit, skip)
+      organization.members_dataset.order(:slug).
+        limit(arguments['limit'], arguments['skip'])
     end)
   end
 end

--- a/app/graphql/types/organizational_unit_type.rb
+++ b/app/graphql/types/organizational_unit_type.rb
@@ -30,9 +30,8 @@ Types::OrganizationalUnitType = GraphQL::InterfaceType.define do
     end
 
     resolve(lambda do |organizational_unit, arguments, _context|
-      limit = arguments[:limit] || target.arguments['limit'].default_value
-      skip = arguments[:skip] || target.arguments['skip'].default_value
-      organizational_unit.repositories_dataset.limit(limit, skip)
+      organizational_unit.repositories_dataset.order(:slug).
+        limit(arguments['limit'], arguments['skip'])
     end)
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -35,9 +35,8 @@ Types::UserType = GraphQL::ObjectType.define do
     end
 
     resolve(lambda do |user, arguments, _context|
-      limit = arguments[:limit] || target.arguments['limit'].default_value
-      skip = arguments[:skip] || target.arguments['skip'].default_value
-      user.organizations_dataset.limit(limit, skip)
+      user.organizations_dataset.order(:slug).
+        limit(arguments['limit'], arguments['skip'])
     end)
   end
 end

--- a/spec/graphql/types/organization_type_spec.rb
+++ b/spec/graphql/types/organization_type_spec.rb
@@ -19,18 +19,30 @@ RSpec.describe Types::OrganizationType do
   context 'members field' do
     let(:members_field) { organization_type.fields['members'] }
     it 'returns only the members' do
-      members = members_field.resolve(organization, {}, {})
-      expect(members.count).to be(20)
+      members = members_field.resolve(
+        organization,
+        members_field.default_arguments,
+        {}
+      )
+      expect(members.count).to eq(20)
     end
 
     it 'limits the member list' do
-      members = members_field.resolve(organization, {limit: 1}, {})
-      expect(members.count).to be(1)
+      members = members_field.resolve(
+        organization,
+        members_field.default_arguments('limit' => 1),
+        {}
+      )
+      expect(members.count).to eq(1)
     end
 
     it 'skips a number of members' do
-      members = members_field.resolve(organization, {skip: 5}, {})
-      expect(members.count).to be(16)
+      members = members_field.resolve(
+        organization,
+        members_field.default_arguments('skip' => 5),
+        {}
+      )
+      expect(members.count).to eq(16)
     end
   end
 end

--- a/spec/graphql/types/organizational_unit_type_spec.rb
+++ b/spec/graphql/types/organizational_unit_type_spec.rb
@@ -8,21 +8,30 @@ RSpec.shared_examples 'an owner of repositories' do
   end
 
   it 'returns only the repositories owned by the organizational unit' do
-    repositories = repositories_field.
-      resolve(organizational_unit, {}, {})
-    expect(repositories.count).to be(20)
+    repositories = repositories_field.resolve(
+      organizational_unit,
+      repositories_field.default_arguments,
+      {}
+    )
+    expect(repositories.count).to eq(20)
   end
 
   it 'limits the repository list' do
-    repositories = repositories_field.
-      resolve(organizational_unit, {limit: 1}, {})
-    expect(repositories.count).to be(1)
+    repositories = repositories_field.resolve(
+      organizational_unit,
+      repositories_field.default_arguments('limit' => 1),
+      {}
+    )
+    expect(repositories.count).to eq(1)
   end
 
   it 'skips a number of repositories' do
-    repositories = repositories_field.
-      resolve(organizational_unit, {skip: 5}, {})
-    expect(repositories.count).to be(16)
+    repositories = repositories_field.resolve(
+      organizational_unit,
+      repositories_field.default_arguments('skip' => 5),
+      {}
+    )
+    expect(repositories.count).to eq(16)
   end
 end
 

--- a/spec/graphql/types/user_type_spec.rb
+++ b/spec/graphql/types/user_type_spec.rb
@@ -19,18 +19,30 @@ RSpec.describe Types::UserType do
   context 'members field' do
     let(:organizations_field) { user_type.fields['organizations'] }
     it 'returns only the organizations to user is a member in' do
-      organizations = organizations_field.resolve(user, {}, {})
-      expect(organizations.count).to be(20)
+      organizations = organizations_field.resolve(
+        user,
+        organizations_field.default_arguments,
+        {}
+      )
+      expect(organizations.count).to eq(20)
     end
 
     it 'limits the organization list' do
-      organizations = organizations_field.resolve(user, {limit: 1}, {})
-      expect(organizations.count).to be(1)
+      organizations = organizations_field.resolve(
+        user,
+        organizations_field.default_arguments('limit' => 1),
+        {}
+      )
+      expect(organizations.count).to eq(1)
     end
 
     it 'skips a number of organizations' do
-      organizations = organizations_field.resolve(user, {skip: 5}, {})
-      expect(organizations.count).to be(16)
+      organizations = organizations_field.resolve(
+        user,
+        organizations_field.default_arguments('skip' => 5),
+        {}
+      )
+      expect(organizations.count).to eq(16)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,14 @@ require 'ontohub-models/factories'
 
 Faker::Config.random = Random.new
 
+module GraphQL
+  class Field
+    def default_arguments(args = {})
+      arguments.transform_values(&:default_value).merge(args)
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`


### PR DESCRIPTION
Postgres has no defined default ordering when using `LIMIT` and `OFFSET`, so `LIMIT 1 OFFSET 0` and `LIMIT 1 OFFSET 1` could return the same row (and in practice this happens; I guess as an optimization). This PR adds an explicit ordering to the fields that accept `limit` and `skip` parameters.

It also moves the default value handling to the `spec_helper.rb` file instead of doing it inside the resolver, as this special handling is only required in tests. Specifically, this adds a monkey patch to provide a `default_arguments` method on `GraphQL::Field`s, but only in tests.