### PR TITLE
Add role filter argument to user's organizations field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: ec0492cc9dd412f1ea193c46db87c61905d36830
+  revision: 1ef1b1a394b4e6785c46fce12abce84661ede54b
   branch: master
   specs:
     ontohub-models (0.1.0)

--- a/app/graphql/types/organization/role_enum.rb
+++ b/app/graphql/types/organization/role_enum.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Types::Organization::RoleEnum = GraphQL::EnumType.define do
+  name 'OrganizationRole'
+  description 'A users role in an organization'
+
+  value 'read'
+  value 'write'
+  value 'admin'
+end

--- a/app/graphql/types/organization/role_enum.rb
+++ b/app/graphql/types/organization/role_enum.rb
@@ -2,7 +2,7 @@
 
 Types::Organization::RoleEnum = GraphQL::EnumType.define do
   name 'OrganizationRole'
-  description 'A users role in an organization'
+  description "A user's role in an organization"
 
   value 'read'
   value 'write'

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -34,8 +34,17 @@ Types::UserType = GraphQL::ObjectType.define do
       default_value 0
     end
 
+    argument :role, Types::Organization::RoleEnum do
+      description 'Filter the organizations by the user\'s role'
+    end
+
     resolve(lambda do |user, arguments, _context|
-      user.organizations_dataset.order(:slug).
+      dataset = if arguments['role']
+                  user.organizations_by_role(arguments['role'])
+                else
+                  user.organizations_dataset
+                end
+      dataset.order(:slug).
         limit(arguments['limit'], arguments['skip'])
     end)
   end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -35,7 +35,7 @@ Types::UserType = GraphQL::ObjectType.define do
     end
 
     argument :role, Types::Organization::RoleEnum do
-      description 'Filter the organizations by the user\'s role'
+      description "Filter the organizations by the user's role"
     end
 
     resolve(lambda do |user, arguments, _context|

--- a/spec/controllers/v2/repositories_controller_spec.rb
+++ b/spec/controllers/v2/repositories_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe V2::RepositoriesController do
 
     describe 'GET index' do
       let!(:another_repository) { create :repository, owner: owner }
-      let!(:other_owner) { create :organizational_unit }
+      let!(:other_owner) { create :user }
       let!(:other_repository) { create :repository, owner: other_owner }
 
       before { get :index, params: {user_slug: owner.to_param} }
@@ -207,7 +207,7 @@ RSpec.describe V2::RepositoriesController do
 
     describe 'GET index' do
       let!(:another_repository) { create :repository, owner: owner }
-      let!(:other_owner) { create :organizational_unit }
+      let!(:other_owner) { create :user }
       let!(:other_repository) { create :repository, owner: other_owner }
 
       before { get :index, params: {organization_slug: owner.to_param} }

--- a/spec/graphql/types/user_type_spec.rb
+++ b/spec/graphql/types/user_type_spec.rb
@@ -50,24 +50,26 @@ RSpec.describe Types::UserType do
     end
 
     context 'filters by role' do
-      it 'returns the organizations with the role: read' do
-        role = 'read'
-        organizations = organizations_field.resolve(
+      let(:organizations) do
+        organizations_field.resolve(
           user,
           organizations_field.default_arguments('role' => role),
           {}
         )
-        expect(organizations.count).to eq(20)
       end
 
-      it 'returns the organizations with the role: admin' do
-        role = 'admin'
-        organizations = organizations_field.resolve(
-          user,
-          organizations_field.default_arguments('role' => role),
-          {}
-        )
-        expect(organizations.count).to eq(1)
+      context 'read' do
+        let(:role) { 'read' }
+        it 'returns the organizations with the role: read' do
+          expect(organizations.count).to eq(20)
+        end
+      end
+
+      context 'admin' do
+        let(:role) { 'admin' }
+        it 'returns the organizations with the role: admin' do
+          expect(organizations.count).to eq(1)
+        end
       end
     end
   end

--- a/spec/support/schema.graphql
+++ b/spec/support/schema.graphql
@@ -497,6 +497,13 @@ input OrganizationChangeset {
   displayName: String
 }
 
+# A users role in an organization
+enum OrganizationRole {
+  admin
+  read
+  write
+}
+
 # Common fields of organizational units
 interface OrganizationalUnit {
   # Display name of the organizational unit
@@ -697,6 +704,9 @@ type User implements OrganizationalUnit {
   organizations(
     # Maximum number of organizations to list
     limit: Int = 20
+
+    # Filter the organizations by the user's role
+    role: OrganizationRole
 
     # Skip the first n organizations
     skip: Int = 0

--- a/spec/support/schema.graphql
+++ b/spec/support/schema.graphql
@@ -497,7 +497,7 @@ input OrganizationChangeset {
   displayName: String
 }
 
-# A users role in an organization
+# A user's role in an organization
 enum OrganizationRole {
   admin
   read


### PR DESCRIPTION
Closes #169. I decided to just use the `organizations` field and add a `role` filter argument.