### PR TITLE
Fix NoMethodError: undefined method join for String

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,10 +50,7 @@ module OntohubBackend
     config.autoload_paths << Rails.root.join('lib')
 
     config.after_initialize do
-      SettingsPresenceValidator.new(Settings).call
-      SettingsNormalizer.new(Settings).call
-      SettingsInitializer.new(Settings).call
-      SettingsValidator.new(Settings).call
+      SettingsHandler.new(Settings).call
     end
 
     # Configure active job to use sneakers/rabbitmq backend

--- a/config/initializers/core_extensions/config.rb
+++ b/config/initializers/core_extensions/config.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# :nocov:
+if Rails.env.development?
+  require 'ostruct'
+
+  # The Rails integration of Config adds a before_action to
+  # ActionController::Base only in the development environment that invokes
+  # ::Config.reload! and cannot be turned off. This monkey-patch makes
+  # ::Config.reload!  append the actions that post-process the Settings.
+  module Config
+    original_definition_of_normalize_path = method(:reload!)
+
+    define_singleton_method(:reload!) do
+      settings = original_definition_of_normalize_path.call
+      SettingsHandler.new(settings).call
+      settings
+    end
+  end
+end
+# :nocov:

--- a/config/initializers/settings_handler.rb
+++ b/config/initializers/settings_handler.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Handles the settings values.
+class SettingsHandler
+  attr_reader :settings
+
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def call
+    SettingsPresenceValidator.new(settings).call
+    SettingsNormalizer.new(settings).call
+    SettingsInitializer.new(settings).call
+    SettingsValidator.new(settings).call
+  end
+end

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -8,6 +8,9 @@ unless defined?(SimpleCov)
 
     # The config of the 'config' gem does not need to be tested.
     add_filter 'config/initializers/config.rb'
+    # The monkey-patch for the development mode of the 'config' gem does not
+    # need to be tested.
+    add_filter 'config/initializers/core_extensions/config.rb'
   end
   require 'codecov'
   formatters = [SimpleCov::Formatter::HTMLFormatter]


### PR DESCRIPTION
This fixes the following error

```text
NoMethodError (undefined method `join' for "data":String):

app/models/repository_compound.rb:26:in `git_directory'
app/models/repository_compound.rb:62:in `git_path'
app/models/repository_compound.rb:56:in `git'
app/graphql/types/repository_type.rb:95:in `block (3 levels) in <top (required)>'
app/graphql/instrumenters/validation_error_instrumenter.rb:16:in `block (2 levels) in instrument'
app/controllers/graphql_controller.rb:10:in `execute'
```

The problem was that [config adds a `before_action` to reload the settings on every request in the development environment](https://github.com/railsconfig/config/blob/1.4.0/lib/config/integrations/rails/railtie.rb#L26-L32). This does not post-process the `Settings`. This pull request monkey-patches `Config`'s public API to append our post-processing.

[This has already been there about seven years ago](https://github.com/railsconfig/config/blob/53257274be8818f6293cab82d40cf4c3a7dfe8b2/lib/rails_config/integration/rails.rb#L25-L27).