### PR TITLE
Improve travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 
 language: ruby
 
+cache: bundler
+
 rvm:
   - 2.4.2
 


### PR DESCRIPTION
Caching bundler cuts the build time on travis roughly in half (2 minutes instead of 4).