### PR TITLE
Use RSpec progress bar formatter: Fuubar.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--format Fuubar
 --require rails_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       before_script:
         - RAILS_ENV=test bundle exec rails db:recreate
       script:
-        - bundle exec rspec
+        - bundle exec rspec --format progress
     - env: WITH_SYSTEM_TEST=1
       gemfile: $HOME/system-test/Gemfile
       services:

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'rack-cors'
 # * `app/graphql/mutations/unlock_account_mutation.rb`
 # when the models bring in a new version of Devise
 gem 'ontohub-models', github: 'ontohub/ontohub-models',
-                      branch: 'upgrade_factory_bot'
+                      branch: 'master'
 
 gem 'gitlab_git', github: 'ontohub/gitlab_git',
                   branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :test do
   gem 'database_cleaner', '~> 1.6.1'
   gem 'factory_bot_rails', '~> 4.8.2'
   gem 'faker', '~> 1.8.4'
+  gem 'fuubar', '~> 2.2.0'
   # As soon as a version > 2.8.0 of json-schema is released, use it instead of
   # master.
   gem 'json-schema', github: 'ruby-json-schema/json-schema', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,9 @@ GEM
     ffi (1.9.18)
     filelock (1.1.1)
     formatador (0.2.5)
+    fuubar (2.2.0)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
     github-linguist (5.3.1)
       charlock_holmes (~> 0.7.5)
       escape_utils (~> 1.1.0)
@@ -397,6 +400,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.8.2)
   faker (~> 1.8.4)
   filelock (~> 1.1.1)
+  fuubar (~> 2.2.0)
   gitlab_git!
   graphiql-rails
   graphql (~> 1.7.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 717f0feba95b65d77686c9ccb4d05ee22a030495
-  branch: upgrade_factory_bot
+  revision: 47b9b0f5fafdf676fb9f54b3d62b08a2574f915e
+  branch: master
   specs:
     ontohub-models (0.1.0)
       awesome_print (~> 1.8.0)
@@ -81,7 +81,7 @@ GEM
     ast (2.3.0)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     bunny (2.7.1)
@@ -101,7 +101,7 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
-    config (1.5.0)
+    config (1.5.1)
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
       dry-validation (~> 0.10.4)
@@ -130,7 +130,7 @@ GEM
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-types (0.12.0)
+    dry-types (0.12.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1)
       dry-container (~> 0.3)
@@ -263,7 +263,7 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.3)
-    rack-cors (1.0.1)
+    rack-cors (1.0.2)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -295,7 +295,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    recaptcha (4.6.1)
+    recaptcha (4.6.2)
       json
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec'
 require 'database_cleaner'
 require 'factory_bot_rails'
 require 'ontohub-models/factories'
+require 'fuubar'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -61,4 +62,8 @@ RSpec.configure do |config|
 
   # Allow to find all factories
   config.include FactoryBot::Syntax::Methods
+
+  config.fuubar_progress_bar_options = {format: '[%B] %c/%C',
+                                        progress_mark: '#',
+                                        remainder_mark: '-'}
 end


### PR DESCRIPTION
This replaces the `progress` formatter (the dots) by the Fuubar formatter (a progress bar) for the development machine. This does not affect Travis.

To see it in action, either check out this branch and run `rspec` or [watch this video of 20 seconds](https://vimeo.com/16845253).