### PR TITLE
Post process analysis jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 47b9b0f5fafdf676fb9f54b3d62b08a2574f915e
+  revision: c5dab310b1000f899bce9100f3cf73afcfdfe717
   branch: master
   specs:
     ontohub-models (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: c5dab310b1000f899bce9100f3cf73afcfdfe717
+  revision: 47b9b0f5fafdf676fb9f54b3d62b08a2574f915e
   branch: master
   specs:
     ontohub-models (0.1.0)

--- a/README.md
+++ b/README.md
@@ -7,29 +7,24 @@
 # ontohub-backend
 The main Ontohub service that serves the data for the frontend and other clients via the [GraphQL API](http://graphql.org/).
 
-## Run the backend
+## Run the backend in development mode
 
 You need to have the `postgres` and `rabbitmq` services started.
+This guide assumes that you have got the [hets-agent](https://github.com/ontohub/hets-agent) located at `../hets-agent` relative to the ontohub-backend repository.
 
+#### With invoker
 We use the [invoker](http://invoker.codemancers.com) process manager during development to run all the needed processes with one command.
-You can start it with either `bundle exec rails invoker` or `bundle exec invoker start invoker.ini` (the former only calls the latter).
+You can start it with either `bundle exec rails invoker` or `bundle exec invoker start invoker.ini` (the former only calls the latter, but consumes more memory).
 
-Alternatively, you can start the processes yourself:
-To run the sneakers workers, run in one terminal `bundle exec rails sneakers:run`.
-The backend can then be started (in another terminal) in development mode with `bundle exec rails server`.
+#### Manually
+Alternatively, you can start the processes yourself by running each of these commands in a separate terminal:
+* `bundle exec rails sneakers:run` to run the sneakers workers
+* `bundle exec rails server` to run the HTTP server of the backend in development mode
+* `pushd ../hets-agent && bin/hets_agent; popd` to run the HetsAgent
 
-The backend is then reachable from the browser at [http://localhost:3000](http://localhost:3000). The interactive GraphiQL console can be accessed at [http://localhost:3000/graphiql](http://localhost:3000/graphiql).
-
-If you are running Linux or macOS, you can reach the backend at [http://ontohub-backend.dev](http://ontohub-backend.dev) after you run
-```text
-sudo -E chruby-exec ruby-$(cat .ruby-version) -- bundle exec invoker setup
-```
-once in the ontohub-backend repository.
-This installs support for `.dev` domains to your system and needs to be done only once.
-To uninstall it, run
-```text
-sudo -E chruby-exec ruby-$(cat .ruby-version) -- bundle exec invoker uninstall
-```
+#### Access the backend
+The backend is then reachable from the browser at [http://localhost:3000](http://localhost:3000).
+The interactive GraphiQL console can be accessed at [http://localhost:3000/graphiql](http://localhost:3000/graphiql).
 
 ## Dependencies
 

--- a/app/jobs/post_process_hets_job.rb
+++ b/app/jobs/post_process_hets_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Post-processes a finished job that was sent to Hets
+class PostProcessHetsJob < ApplicationJob
+  queue_as :post_process_hets
+
+  def perform(result, original_job_message)
+    return unless result == 'success'
+
+    post_processing_result = post_process(JSON.parse(original_job_message))
+    requeue(result, original_job_message) if post_processing_result == :requeue
+    post_processing_result
+  end
+
+  protected
+
+  def post_process(parsed_original_job)
+    case parsed_original_job['action']
+    when 'analysis'
+      ImportingDocumentsReanalyzer.
+        new(parsed_original_job['arguments']['file_version_id']).call
+    end
+  end
+
+  def requeue(*job_arguments)
+    # 10 Seconds is just an arbitrary value. We need to wait for the analysis
+    # jobs to finish before we can try to post-process this one again.
+    sleep 10
+    PostProcessHetsJob.perform_later(*job_arguments)
+  end
+end

--- a/app/jobs/process_commit_job.rb
+++ b/app/jobs/process_commit_job.rb
@@ -8,6 +8,17 @@ class ProcessCommitJob < ApplicationJob
     FileVersionParentsCreator.new(repository_id, commit_sha).call
     request_collection =
       HetsAgent::AnalysisRequestCollection.new(repository_id, commit_sha)
+    finish_non_documents(repository_id, commit_sha, request_collection)
     HetsAgent::Invoker.new(request_collection).call
+  end
+
+  protected
+
+  def finish_non_documents(repository_id, commit_sha, requests)
+    documents_ids = requests.map { |r| r[:arguments][:file_version_id] }
+    all_file_versions = FileVersion.where(repository_id: repository_id,
+                                          commit_sha: commit_sha)
+    non_documents = all_file_versions.exclude(id: documents_ids)
+    non_documents.update(evaluation_state: 'finished_successfully')
   end
 end

--- a/app/workers/post_process_hets_worker.rb
+++ b/app/workers/post_process_hets_worker.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Worker for the commit queue
+class PostProcessHetsWorker < ApplicationWorker
+  from_queue :post_process_hets, threads: 1, prefetch: 1, timeout_job_after: nil
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module OntohubBackend
   # The base application class - Rails default
   class Application < Rails::Application
     config.hets_version_requirement = '>= 0.100.0'
+    config.document_file_extensions =
+      %w(casl dol hascasl het owl omn obo hs exp maude elf hol isa thy prf
+         omdoc hpf clf clif xml fcstd rdf xmi qvt p tptp gen_trm baf).
+        map { |ext| ".#{ext}" }
 
     # Settings in config/environments/* take precedence over those specified
     # here.

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -5,7 +5,10 @@ if Rails.env.test?
   Sneakers.configure(connection: BunnyMock.new)
 else
   # :nocov:
-  Sneakers.configure(connection: Bunny.new)
-  Sneakers.logger.level = Logger::WARN
+  Sneakers.configure(connection: Bunny.new(username: Settings.rabbitmq.username,
+                                           password: Settings.rabbitmq.password,
+                                           host: Settings.rabbitmq.host,
+                                           port: Settings.rabbitmq.port))
+  Sneakers.logger.level = Logger::ERROR
   # :nocov:
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,5 @@ sneakers:
     workers: 1
   - classes: ProcessCommitWorker
     workers: 1
+  - classes: PostProcessHetsWorker
+    workers: 1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,12 @@ jwt:
 # This directory will be created if it does not exist.
 data_directory: 'data'
 
+rabbitmq:
+  host: localhost
+  port: 5672
+  username: guest
+  password: guest
+
 sneakers:
   - classes: MailersWorker
     workers: 1

--- a/db/seeds/001_clear_queue.rb
+++ b/db/seeds/001_clear_queue.rb
@@ -4,10 +4,14 @@ connection = Sneakers::CONFIG[:connection]
 begin
   connection.start
   channel = connection.create_channel
-  queue = channel.queue(HetsAgent::Invoker::WORKER_QUEUE_NAME,
-                        durable: true,
-                        auto_delete: false)
-  queue.purge
+
+  channel.queue(HetsAgent::Invoker::WORKER_QUEUE_NAME,
+                durable: true,
+                auto_delete: false).purge
+
+  channel.queue('post_process_hets',
+                durable: true,
+                auto_delete: false).purge
 ensure
   connection.close
 end

--- a/db/seeds/045_document_seeds.rb
+++ b/db/seeds/045_document_seeds.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+documents = Rails.root.join('db/seeds/fixtures/documents')
+
+ada_fixtures_repo = RepositoryCompound.find(slug: 'ada/fixtures')
+
+%w(Numbers.casl RelationsAndOrders.casl).each do |file|
+  FactoryBot.
+    create(:additional_file,
+           repository: ada_fixtures_repo,
+           commit_message: "Create #{file}",
+           user: ada_fixtures_repo.owner,
+           path: File.join('Basic', file),
+           content: File.read(documents.join(file)),
+           encoding: 'plain')
+end
+
+FactoryBot.
+  create(:additional_commit,
+         repository: ada_fixtures_repo,
+         user: ada_fixtures_repo.owner,
+         commit_message: 'Delete both casl files again.',
+         files: [{path: File.join('Basic', 'Numbers.casl'),
+                  action: 'remove'},
+                 {path: File.join('Basic',
+                                  'RelationsAndOrders.casl'),
+                  action: 'remove'}])
+
+%w(Numbers.casl RelationsAndOrders.casl).each do |file|
+  FactoryBot.
+    create(:additional_file,
+           repository: ada_fixtures_repo,
+           commit_message: "Recreate #{file}.",
+           user: ada_fixtures_repo.owner,
+           path: File.join('Basic', file),
+           content: File.read(documents.join(file)),
+           encoding: 'plain')
+end
+
+FactoryBot.
+  create(:additional_commit,
+         repository: ada_fixtures_repo,
+         user: ada_fixtures_repo.owner,
+         commit_message: 'Create some NativeDocuments.',
+         files: [{path: File.join('NativeDocuments', 'cat.clif'),
+                  content: File.read(documents.join('cat.clif')),
+                  encoding: 'plain',
+                  action: 'create'},
+                 {path: File.join('NativeDocuments', 'pizza.owl'),
+                  content: File.read(documents.join('pizza.owl')),
+                  encoding: 'plain',
+                  action: 'create'}])
+
+content = "#{File.read(documents.join('Numbers.casl'))}\n"
+FactoryBot.
+  create(:additional_commit,
+         repository: ada_fixtures_repo,
+         user: ada_fixtures_repo.owner,
+         commit_message: 'Append newline: Numbers.casl.',
+         files: [{path: File.join('Basic', 'Numbers.casl'),
+                  content: content,
+                  encoding: 'plain',
+                  action: 'update'}])
+
+FactoryBot.
+  create(:additional_commit,
+         repository: ada_fixtures_repo,
+         user: ada_fixtures_repo.owner,
+         commit_message: 'Add newline: NativeDocuments.',
+         files: [{path: File.join('NativeDocuments', 'cat.clif'),
+                  content: "#{File.read(documents.join('cat.clif'))}\n",
+                  encoding: 'plain',
+                  action: 'update'},
+                 {path: File.join('NativeDocuments', 'pizza.owl'),
+                  content: "#{File.read(documents.join('pizza.owl'))}\n",
+                  encoding: 'plain',
+                  action: 'update'}])
+
+content = "#{File.read(documents.join('RelationsAndOrders.casl'))}\n"
+FactoryBot.
+  create(:additional_commit,
+         repository: ada_fixtures_repo,
+         user: ada_fixtures_repo.owner,
+         commit_message: 'Append newline: RelationsAndOrders.casl.',
+         files: [{path:
+                    File.join('Basic', 'RelationsAndOrders.casl'),
+                  content: content,
+                  encoding: 'plain',
+                  action: 'update'}])
+
+# Create some Hets-lib files in a subdirectory, using a UrlMapping
+
+organization_fixtures_repo =
+  RepositoryCompound.find(slug: 'seed-user-organization/fixtures')
+
+UrlMapping.create(repository_id: organization_fixtures_repo.id,
+                  source: 'Basic/',
+                  target: 'Hets-lib/Basic/')
+
+%w(Numbers.casl RelationsAndOrders.casl).each do |file|
+  FactoryBot.create(:additional_file,
+                     repository: organization_fixtures_repo,
+                     commit_message: "Create #{file}",
+                     user: User.first(slug: 'ada'),
+                     path: File.join('Hets-lib/Basic', file),
+                     content: File.read(documents.join(file)),
+                     encoding: 'plain')
+end

--- a/db/seeds/fixtures/documents/Numbers.casl
+++ b/db/seeds/fixtures/documents/Numbers.casl
@@ -1,0 +1,390 @@
+library Basic/Numbers
+version 1.0
+%authors: M. Roggenbach <csmarkus@swansea.ac.uk>, T. Mossakowski, L. Schroeder
+%date: 18 December 2003
+
+%{ This library provides specifications of naturals, integers, and
+rationals. Concerning the rationals, the specification Rat includes
+the datatype proper, while the specification DecimalFraction adds the
+notions needed to represent rationals as decimal fractions. }%
+
+%display __<=__ %LATEX __\leq__
+%display __>=__ %LATEX __\geq__
+
+%prec(
+  { __ -? __ , __ - __, __ + __ } <
+  { __*__, __ /? __, __ / __, __div__, __mod__, __ quot __, __rem__ }
+)%
+
+%prec(
+  { __*__, __ /? __, __ / __, __div__, __mod__, __ quot __, __rem__ } <
+  { __ ^ __}
+)%
+
+%prec( {-__} <> {__ ^ __} )%
+
+%prec { __ E __ } < { __ ::: __ }
+
+%left_assoc __ + __, __ * __, __ @@ __
+
+%number __@@__
+
+%floating __:::__, __E__
+
+spec Nat = %mono
+
+  free type Nat ::= 0 | suc(pre:? Nat)
+
+  preds   __ <= __, __ >= __, __dvd__,
+          __ <  __, __ > __:   Nat * Nat;
+          even, odd:           Nat
+
+  ops   __! :                       Nat -> Nat;
+        __ + __, __ * __, __ ^ __,
+        min, max, __ -!__ :         Nat * Nat ->  Nat;
+        __ -?__, __ /? __,
+        __ div __, __ mod __:       Nat * Nat ->? Nat;
+
+  %% Operations to represent natural numbers with digits:
+
+  ops  1: Nat = suc (0);                      %(1_def_Nat)%
+       2: Nat = suc (1);                      %(2_def_Nat)%
+       3: Nat = suc (2);                      %(3_def_Nat)%
+       4: Nat = suc (3);                      %(4_def_Nat)%
+       5: Nat = suc (4);                      %(5_def_Nat)%
+       6: Nat = suc (5);                      %(6_def_Nat)%
+       7: Nat = suc (6);                      %(7_def_Nat)%
+       8: Nat = suc (7);                      %(8_def_Nat)%
+       9: Nat = suc (8);                      %(9_def_Nat)%
+
+       __ @@ __ (m:Nat;n:Nat): Nat = (m * suc(9)) + n   %(decimal_def)%
+
+  %% implied operation attributes :
+
+  ops __+__: Nat * Nat -> Nat,
+             comm, assoc, unit 0; %implied
+      __*__: Nat * Nat -> Nat,
+             comm, assoc, unit 1; %implied
+      min:   Nat * Nat -> Nat,
+             comm, assoc;         %implied
+      max:   Nat * Nat -> Nat,
+             comm, assoc, unit 0; %implied
+
+  forall m,n,r,s,t : Nat
+
+  %% axioms concerning predicates
+
+     . 0 <= n                           %(leq_def1_Nat)% %simp
+     . m dvd n <=> (exists k : Nat . n = m * k) %(dvd_def_Nat)% %simp
+     . not suc(n) <= 0                  %(leq_def2_Nat)% %simp
+     . suc(m) <= suc(n) <=> m <= n      %(leq_def3_Nat)% %simp
+
+     . m >= n <=> n <= m                %(geq_def_Nat)% %simp
+     . m < n  <=> (m <= n /\ not m=n)   %(less_def_Nat)% %simp
+     . m > n  <=> n < m                 %(greater_def_Nat)% %simp
+
+     . even(0)                          %(even_0_Nat)% %simp
+     . even(suc(m)) <=> odd(m)          %(even_suc_Nat)% %simp
+     . odd(m) <=> not even(m)           %(odd_def_Nat)% %simp
+
+  %% axioms concerning operations
+
+     . 0! = 1                           %(factorial_0)% %simp
+     . suc(n)! =suc(n)*n!               %(factorial_suc)% %simp
+
+     . 0 + m = m                        %(add_0_Nat)% %simp
+     . suc(n) + m = suc(n + m)          %(add_suc_Nat)% %simp
+
+     . 0 * m = 0                        %(mult_0_Nat)% %simp
+     . suc(n) * m = (n * m) + m         %(mult_suc_Nat)% %simp
+     . m ^ 0 = 1                        %(power_0_Nat)% %simp
+     . m ^ suc(n)  = m * m ^ n          %(power_suc_Nat)% %simp
+
+     . min(m,n) = m when m <= n else n  %(min_def_Nat)%
+     . max(m,n) = n when m <= n else m  %(max_def_Nat)%
+
+     . n -! m = 0      if m >  n        %(subTotal_def1_Nat)% %simp
+     . n -! m = n -? m if m <= n        %(subTotal_def2_Nat)% %simp
+
+     . def(m-?n) <=> m >= n             %(sub_dom_Nat)% %implied
+     . m -? n = r <=> m = r + n         %(sub_def_Nat)%
+
+     . def(m /? n) <=>
+       not n=0 /\ m mod n = 0               %(divide_dom_Nat)% %implied
+     . not def(m /? 0)                      %(divide_0_Nat)%
+     . ( m /? n = r <=> m = r * n ) if n>0  %(divide_Pos_Nat)%
+
+     . def ( m div n ) <=> not n=0             %(div_dom_Nat)% %implied
+     . m div n = r <=>
+       (exists s: Nat . m = n*r + s /\ s < n)  %(div_Nat)%
+
+     . def ( m mod n ) <=> not n=0             %(mod_dom_Nat)% %implied
+     . m mod n = s <=>
+       (exists r: Nat . m = n*r + s /\ s < n)  %(mod_Nat)%
+
+  %% important laws
+
+     . (r + s) * t = (r * t) + (s * t)  %(distr1_Nat)% %implied
+     . t * (r + s) = (t * r) + (t * s)  %(distr2_Nat)% %implied
+
+then %mono
+     sort Pos = { p: Nat . p > 0 } %(Pos_def)%
+     ops   suc: Nat -> Pos;
+           1: Pos = suc(0);             %(1_as_Pos_def)%
+           __*__: Pos * Pos -> Pos;
+           __+__: Pos * Nat -> Pos;
+           __+__: Nat * Pos -> Pos
+
+then %implies
+
+     forall m,n,r,s:Nat
+     . min(m,0)=0                                  %(min_0)%  %simp
+     . m = (m div n) * n + (m mod n) if not n = 0  %(div_mod_Nat)%
+     . m ^(r+s) = m^r * m^s                        %(power_Nat)%
+
+end
+
+spec Int = %mono
+
+  Nat
+
+then %mono
+
+     generated type Int ::= __ - __(Nat;Nat)
+     forall a,b,c,d: Nat
+     .  a - b = c - d <=> a + d = c + b    %(equality_Int)%
+
+     sort  Nat < Int
+     forall a: Nat . a = a - 0             %(Nat2Int_embedding)%
+then %def
+
+     preds __ <= __, __ >= __,
+           __ <  __, __ >  __: Int * Int;
+           even, odd :         Int
+
+     ops  - __, sign: Int -> Int;
+          abs:        Int -> Nat;
+          __ + __,__ * __, __ - __,
+          min, max:                          Int * Int -> Int;
+          __ ^ __:                           Int * Nat -> Int;
+          __ /? __,
+          __ div __, __ quot __, __ rem __ : Int * Int ->? Int;
+          __ mod __:                         Int * Int ->? Nat;
+          0,1,2,3,4,5,6,7,8,9:               Int
+
+  %% implied operation attributes :
+
+     ops __+__:   Int * Int -> Int,
+                  comm, assoc, unit 0; %implied
+         __*__:   Int * Int -> Int,
+                  comm, assoc, unit 1; %implied
+         min,max: Int * Int -> Int,
+                  comm, assoc;         %implied
+
+     forall  m,n,r,s,t: Int; a,b,c,d: Nat
+
+  %% axioms concerning predicates
+
+     . m <= n <=> n - m in Nat                 %(leq_def_Int)%     %simp
+     . m >= n <=> n <= m                       %(geq_def_Int)%
+     . m < n <=> (m <= n /\ not m=n)           %(less_def_Int)%
+     . m > n <=> n < m                         %(greater_def_Int)%
+
+     . even(m) <=> even(abs(m))                %(even_def_Int)%    %simp
+     . odd(m)  <=> not even(m)                 %(odd_def_Int)%
+     . odd(m)  <=> odd(abs(m))                 %(odd_alt_Int)%     %simp
+
+  %% axioms concerning operations
+
+     . - (a - b) = b - a                       %(neg_def_Int)%     %simp
+
+     . sign(m) = 0 when m = 0
+           else (1 when m > 0 else -1)         %(sign_def_Int)%    %simp
+
+     . abs(m) = - m when m < 0
+            else  m                            %(abs_def_Int)%     %simp
+
+     . (a - b) + (c - d) = (a + c) - (b + d)   %(add_def_Int)%     %simp
+     . (a - b) * (c - d) =
+       (a * c + b * d) - (b * c + a * d)       %(mult_def_Int)%    %simp
+     .  m - n = m + ( - n )                    %(sub_def_Int)%     %simp
+
+     . min(m,n) = m when m <= n else n         %(min_def_Int)%     %simp
+     . max(m,n) = n when m <= n else m         %(max_def_Int)%     %simp
+
+     . (- 1) ^ a = 1 when even(a) else - 1     %(power_neg1_Int)%  %simp
+     . m ^ a = sign(m)^a * abs(m)^a
+       if not m = -1                           %(power_others_Int)% %simp
+
+     . def (m /? n) <=> m mod n = 0            %(divide_dom2_Int)% %implied
+     . m /? n = r <=> not n = 0 /\ n * r = m   %(divide_alt_Int)% %implied
+     . m /? n =
+       sign(m) * sign(n) * (abs(m) /? abs(n))  %(divide_Int)%              %simp
+
+     . def ( m div n ) <=> not n=0             %(div_dom_Int)% %implied
+     . m div n = r <=>
+       (exists a: Nat .
+        m = n*r + a /\ a < abs(n) )            %(div_Int)%                 %simp
+
+
+     . def ( m quot n ) <=> not n=0            %(quot_dom_Int)% %implied
+     . (m quot n = r <=>
+         (exists s: Int .
+           m = n*r + s /\
+             0 >= s /\ s > - abs(n) )
+       ) if m < 0                              %(quot_neg_Int)%            %simp
+     . (m quot n = r <=>
+         (exists s: Int .
+            m = n*r + s /\
+              0 <= s /\ s < abs(n) )
+       ) if m >= 0                             %(quot_nonneg_Int)%         %simp
+
+     . def ( m rem n ) <=> not n=0             %(rem_dom_Int)% %implied
+     . (m rem n = s <=>
+         (exists r: Int .
+           m = n*r + s /\
+             0 >= s /\ s > - abs(n) )
+       ) if m < 0                              %(rem_neg_Int)%            %simp
+     . (m rem n = s <=>
+         (exists r: Int .
+            m = n*r + s /\
+              0 <= s /\ s < abs(n) )
+       ) if m >= 0                             %(rem_nonneg_Int)%         %simp
+
+     . def ( m mod n ) <=> not n=0             %(mod_dom_Int)% %implied
+     . m mod n = a <=>
+       (exists r: Int .
+        m = n*r + a /\ a < abs(n))             %(mod_Int)%                %simp
+
+  %% important laws
+
+     . (r + s) * t = (r * t) + (s * t)  %(distr1_Int)% %implied
+     . t * (r + s) = (t * r) + (t * s)  %(distr2_Int)% %implied
+
+then %implies
+
+     forall m,n,r: Int; a,b: Nat
+     . def(a -? b) => a -? b = a - b                %(Int_Nat_sub_compat)%
+
+     . m = sign(m) * abs(m)                         %(abs_decomp_Int)%
+
+     . m mod n = m mod abs(n)                       %(mod_abs_Int)%
+
+     . m = (m div n) * n + (m mod n) if not n = 0   %(div_mod_Int)%
+
+     . abs(m quot n) = abs(m) quot abs(n)           %(quot_abs_Int)%
+     . abs(m rem  n) = abs(m) rem  abs(n)           %(rem_abs_Int)%
+     . m = (m quot n) * n + (m rem n) if not n = 0  %(quot_rem_Int)%
+
+     . m ^(a+b) = m^a * m^b                         %(power_Int)%
+
+end
+
+spec Rat = %mono
+
+     Int
+
+then %mono
+
+     generated type Rat ::= __ / __ (Int;Pos)
+     forall i,j: Int; p,q: Pos
+     . i / p = j / q <=> i*q = j*p              %(equality_Rat)%
+
+     sort Int < Rat
+     forall i:Int . i = i / 1                   %(Int2Rat_embedding)%
+
+then %def
+
+     preds    __ <= __, __ < __,
+              __ >= __, __ > __: Rat * Rat;
+
+     ops -__, abs:  Rat -> Rat;
+         __ + __,__ - __, __ * __,
+         min,max:                   Rat * Rat -> Rat;
+         __ / __ :                  Rat * Rat ->? Rat;
+         __ ^ __:                   Rat * Int ->? Rat;
+         0,1,2,3,4,5,6,7,8,9:       Rat
+
+  %% implied operation attributes :
+
+     ops __+__:   Rat * Rat -> Rat,
+                  comm, assoc, unit 0; %implied
+         __*__:   Rat * Rat -> Rat,
+                  comm, assoc, unit 1; %implied
+         min,max: Rat * Rat -> Rat,
+                  comm, assoc;         %implied
+
+     forall p,q:Pos; n:Nat; i,j: Int; x,y,z: Rat
+
+  %% axioms concerning predicates
+
+     . (i / p <= j / q <=> i * q <= j * p ) %(leq_def_Rat)%
+     . x >= y <=> y <= x                    %(geq_def_Rat)%
+     . x < y <=> (x <= y /\ not x=y )       %(less_def_Rat)%
+     . x > y <=> y < x                      %(greater_def_Rat)%
+
+  %% axioms concerning operations
+
+     . - (i/p) = (-i)/p                 %(minus_def_Rat)%
+
+     . abs(i / p) = abs(i) / p          %(abs_def_Rat)%
+
+     . (i / p) + (j / q) =
+       (i * q + j * p) / (p * q)        %(add_def_Rat)%
+
+     . x-y = x + (-y)                   %(sub_def_Rat)%
+
+     . (i / p) * (j / q) =
+       (i * j) / (p * q)                %(mult_def_Rat)%
+
+     . min(x,y) = x when x <= y else y  %(min_def_Rat)%
+     . max(x,y) = y when x <= y else x  %(max_def_Rat)%
+
+     . not def x/0                      %(divide_def1_Rat)%
+     . (x/y=z <=> x=z*y)
+       if not y = 0                     %(divide_def2_Rat)%
+
+     . x ^ 0 = 1                        %(power_0_Rat)%
+     . x ^ suc(n) = x * x ^ n           %(power_suc_Rat)%
+     . x ^ (-p) = 1 / (x ^ p)           %(power_neg_Rat)%
+
+  %% important laws
+
+     . (x + y) * z = (x * z) + (y * z)  %(distr1_Rat)% %implied
+     . z * (x + y) = (z * x) + (z * y)  %(distr2_Rat)% %implied
+
+then %implies
+
+     forall i,j: Int; p,q:Pos; x,y:Rat
+     . (i / p) - (j / q) =
+       (i * q - j * p) / (p * q)        %(sub_rule_Rat)%
+
+
+     . def (x/y) <=> not y = 0          %(divide_dom_Rat)%
+     . (i/p) / (j/q) =
+       (i * q ) / (p * j) if not j=0    %(divide_rule_Rat)%
+
+     . x^(i+j) = x^i * x^j              %(power_Rat)%
+
+end
+
+spec DecimalFraction = %mono
+     Rat
+then %def
+local
+     op   tenPower: Nat -> Nat
+     forall n,m: Nat
+     %% tenPower(n):= min { 10^k | k in N \{0}, 10^k > n }:
+     . tenPower(n)= 10 when n < 10 else
+                    10 * tenPower(n div 10)    %(tenPower_def)%
+within
+     %% operations to represent a rational as a decimal fraction:
+     ops   __ ::: __ : Nat * Nat -> Rat;
+           __ E __ :   Rat * Int -> Rat
+     forall r:Rat; n,m: Nat; p: Pos; i:Int
+     %%  represent the decimal fraction n.m as rational:
+     . n:::m = n + (m/tenPower(m))             %(decfract_def)%
+
+     %%  introduce an exponent:
+     . r E i = r * (10 ^ i)                    %(exponent_DecimalFraction)%
+end

--- a/db/seeds/fixtures/documents/RelationsAndOrders.casl
+++ b/db/seeds/fixtures/documents/RelationsAndOrders.casl
@@ -1,0 +1,247 @@
+library Basic/RelationsAndOrders
+version 1.0
+%authors: M. Roggenbach <csmarkus@swansea.ac.uk>, T. Mossakowski, L. Schroeder
+%date: 18 December 2003
+
+%{ This library provides
+
+- specifications of binary relations of different sort,
+- views stating that the numbers specified in the
+   Library Basic/Numbers are totally ordered, and
+- a specification of Boolean Algebras.
+
+Then, the different concepts specified are enriched with additional
+operations and predicates: In case of partial orders, the specification
+ExtPartialOrder provides the notions of inf, sup; the specification
+ExtTotalOrder adds the functions min and max to total orders;
+ExtBooleanAlgebra defines a complement operation as well as a
+less-or-equal relation for Boolean algebras.
+
+Finally, the library provides non parametrized variants of these
+enriched specifications. }%
+
+%display __~__    %LATEX __\sim__
+%display __<=__    %LATEX __\leq__
+%display __>=__    %LATEX __\geq__
+%display __cup __ %LATEX __\sqcup__
+%display __cap __ %LATEX __\sqcap__
+%display compl__  %LATEX __^{-1}
+
+%prec { __ cup __ } < { __ cap __}
+
+from Basic/Numbers get Nat, Int, Rat
+
+
+spec Relation =
+     sort Elem
+     pred __ ~ __: Elem * Elem
+end
+
+spec ReflexiveRelation =
+     Relation
+then
+     forall x:Elem
+     . x ~ x                        %(refl)%
+end
+
+spec IrreflexiveRelation =
+     Relation
+then
+     forall x:Elem
+     . not x ~ x                  %(irrefl)%
+end
+
+spec SymmetricRelation =
+     Relation
+then forall x,y:Elem
+     . x ~ y if y ~ x                %(sym)%
+end
+
+spec AsymmetricRelation =
+     Relation
+then forall x,y:Elem
+     . not x ~ y if y ~ x           %(asym)%
+end
+
+spec AntisymmetricRelation =
+     Relation
+then forall x,y:Elem
+     . x = y if x ~ y /\ y ~ x %(antisym)%
+end
+
+spec TransitiveRelation =
+     Relation
+then forall x,y,z:Elem
+     . x ~ z if x ~ y /\ y ~ z     %(trans)%
+end
+
+spec SimilarityRelation =
+     ReflexiveRelation and SymmetricRelation
+end
+
+spec PartialEquivalenceRelation =
+     SymmetricRelation and TransitiveRelation
+end
+
+spec EquivalenceRelation =
+     ReflexiveRelation and PartialEquivalenceRelation
+end
+
+spec PreOrder =
+     {ReflexiveRelation and TransitiveRelation}
+     with pred __ ~ __ |-> __ <= __
+end
+
+spec StrictOrder =
+     { {IrreflexiveRelation and TransitiveRelation}
+       then %implies
+             AsymmetricRelation }
+     with pred __ ~ __ |-> __ < __
+end
+
+spec PartialOrder =
+     PreOrder
+and  AntisymmetricRelation with pred __ ~ __ |-> __ <= __
+end
+
+spec TotalOrder =
+     PartialOrder
+then forall x,y:Elem
+     . x <= y \/ y <= x                    %(dichotomy_TotalOrder)%
+end
+
+spec StrictTotalOrder =
+     StrictOrder
+then forall x,y:Elem
+     . x < y \/ y < x \/ x=y        %(trichotomy_StrictTotalOrder)%
+end
+
+spec RightUniqueRelation =
+     sorts S, T
+     pred __ R __: S * T
+     forall s:S; t1,t2:T
+     . s R t1 /\ s R t2 => t1=t2
+end
+
+spec LeftTotalRelation =
+     sorts S, T
+     pred __ R __: S * T
+     forall s:S . exists t:T . s R t
+end
+
+spec BooleanAlgebra =
+
+     sort Elem
+
+     ops 0,1:       Elem;
+         __ cap __: Elem * Elem -> Elem, assoc, comm, unit 1;
+         __ cup __: Elem * Elem -> Elem, assoc, comm, unit 0;
+
+     forall x,y,z:Elem
+
+     . x cap ( x cup y) = x             %(absorption_def1)%
+     . x cup ( x cap y) = x             %(absorption_def2)%
+
+     . x cap 0 = 0                      %(zeroAndCap)%
+     . x cup 1 = 1                      %(oneAndCup)%
+
+     . x cap ( y cup z) = (x cap y) cup ( x cap z)
+                                        %(distr1_BooleanAlgebra)%
+     . x cup ( y cap z) = (x cup y) cap ( x cup z)
+                                        %(distr2_BooleanAlgebra)%
+
+     . exists x': Elem . x cup x' = 1 /\ x cap x' = 0
+                                        %(inverse_BooleanAlgebra)%
+
+then %implies
+
+     op __ cup __, __ cap __ : Elem * Elem -> Elem , idem
+
+     forall x: Elem
+     . exists! x': Elem .
+         x cup x' = 1 /\ x cap x' = 0   %(uniqueComplement_BooleanAlgebra)%
+end
+
+
+spec ExtPartialOrder [PartialOrder]
+= %def
+  {  preds __ <= __, __ < __,
+           __ >= __, __ > __: Elem * Elem;
+     forall x,y:Elem
+     . x >= y <=> y <= x                   %(geq_def_ExtPartialOrder)%
+     . x < y <=> (x <= y /\ not (x=y))     %(less_def_ExtPartialOrder)%
+     . x > y <=> y < x                     %(greater_def_ExtPartialOrder)%
+  }
+and
+  { ops inf,sup : Elem * Elem ->? Elem,
+                  comm %implied
+    forall x,y,z: Elem
+    . inf(x,y) = z <=>
+      z <= x /\ z <= y /\ (forall t: Elem . t <= x /\ t <= y => t <= z)
+                                      %(inf_def_ExtPartialOrder)%
+    . sup(x,y) = z <=>
+      x <= z /\ y <= z /\ (forall t: Elem . x <= t /\ y <= t => z <= t)
+                                      %(sup_def_ExtPartialOrder)%
+  }
+end
+
+spec ExtTotalOrder [TotalOrder] = %def
+  ExtPartialOrder [PartialOrder]
+and
+  { ops min, max: Elem * Elem -> Elem,
+                  comm,assoc %implied
+    forall x,y: Elem
+    . min(x,y) = x when x <= y else y      %(min_def_ExtTotalOrder)%
+    . max(x,y) = y when x <= y else x      %(max_def_ExtTotalOrder)%
+  }
+then %implies
+     forall x,y: Elem
+     . min(x,y)=inf(x,y)             %(min_inf_relation)%
+     . max(x,y)=sup(x,y)             %(max_sup_relation)%
+end
+
+spec ExtBooleanAlgebra [BooleanAlgebra] = %def
+     {   preds __ <= __, __ < __,
+               __ >= __, __ > __: Elem * Elem;
+         forall x,y:Elem
+         . x <= y <=> x cap y = x           %(leq_def_ExtBooleanAlgebra)%
+         . x >= y <=> y <= x                %(geq_def_ExtBooleanAlgebra)%
+         . x < y <=> (x <= y /\ not (x=y))  %(less_def_ExtBooleanAlgebra)%
+         . x > y <=> y < x                  %(greater_def_ExtBooleanAlgebr)%
+     }
+and
+     { op compl__: Elem -> Elem
+       forall x,y:Elem
+       . compl(x)=y <=> x cup y = 1 /\ x cap y = 0
+                                            %(compl_def_ExtBooleanAlgebra)%
+
+     then %implies
+       forall x,y: Elem
+       . compl(x cap y) = compl(x) cup compl(y)             %(de_Morgan1)%
+       . compl(x cup y) = compl(x) cap compl(y)             %(de_Morgan2)%
+       . compl(compl(x)) = x        %(involution_compl_ExtBooleanAlgebra)%
+
+     }
+end
+
+spec RichPartialOrder   = ExtPartialOrder   [PartialOrder]
+spec RichTotalOrder     = ExtTotalOrder     [TotalOrder]
+spec RichBooleanAlgebra = ExtBooleanAlgebra [BooleanAlgebra]
+
+
+
+view TotalOrder_in_Nat : TotalOrder to Nat =
+     sort Elem |-> Nat
+end
+
+view TotalOrder_in_Int : TotalOrder to Int =
+     sort Elem |-> Int
+end
+
+view TotalOrder_in_Rat : TotalOrder to Rat =
+     sort Elem |-> Rat
+end
+
+view PartialOrder_in_ExtBooleanAlgebra [BooleanAlgebra] :
+   PartialOrder to ExtBooleanAlgebra[BooleanAlgebra]
+end

--- a/db/seeds/fixtures/documents/cat.clif
+++ b/db/seeds/fixtures/documents/cat.clif
@@ -1,0 +1,8 @@
+(cl-text Cat
+  (P x)
+  (and (P x) (Q y))
+  (or (Cat x) (Mat y))
+  (not (On x y))
+  (if (P x) (Q x))
+  (exists (z) (and (Pet x) (Happy z) (Attr x z)))
+)

--- a/db/seeds/fixtures/documents/pizza.owl
+++ b/db/seeds/fixtures/documents/pizza.owl
@@ -1,0 +1,3100 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY owl11 "http://www.w3.org/2006/12/owl11#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY owl11xml "http://www.w3.org/2006/12/owl11-xml#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY pizza "http://www.co-ode.org/ontologies/pizza/pizza.owl#" >
+]>
+
+
+<rdf:RDF xmlns="http://www.co-ode.org/ontologies/pizza/pizza.owl#"
+     xml:base="http://www.co-ode.org/ontologies/pizza/pizza.owl"
+     xmlns:owl11="http://www.w3.org/2006/12/owl11#"
+     xmlns:pizza="http://www.co-ode.org/ontologies/pizza/pizza.owl#"
+     xmlns:owl11xml="http://www.w3.org/2006/12/owl11-xml#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#">
+    <owl:Ontology rdf:about="">
+        <rdfs:comment xml:lang="en"
+            >An example ontology that contains all constructs required for the various versions of the Pizza Tutorial run by Manchester University (see http://www.co-ode.org/resources/tutorials/)</rdfs:comment>
+        <owl:versionInfo xml:lang="en"
+            >v.1.5. Removed protege.owl import and references. Made ontology URI date-independent</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="&xsd;string">version 1.5</owl:versionInfo>
+        <owl:versionInfo xml:lang="en"
+            >v.1.4. Added Food class (used in domain/range of hasIngredient), Added several hasCountryOfOrigin restrictions on pizzas, Made hasTopping invers functional</owl:versionInfo>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#hasBase -->
+
+    <owl:ObjectProperty rdf:about="#hasBase">
+        <rdf:type rdf:resource="&owl;InverseFunctionalProperty"/>
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:subPropertyOf rdf:resource="#hasIngredient"/>
+        <rdfs:range rdf:resource="#PizzaBase"/>
+        <rdfs:domain rdf:resource="#Pizza"/>
+        <owl:inverseOf rdf:resource="#isBaseOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#hasCountryOfOrigin -->
+
+    <owl:ObjectProperty rdf:about="#hasCountryOfOrigin"/>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#hasIngredient -->
+
+    <owl:ObjectProperty rdf:about="#hasIngredient">
+        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+        <rdfs:comment xml:lang="en"
+            >NB Transitive - the ingredients of ingredients are ingredients of the whole</rdfs:comment>
+        <owl:inverseOf rdf:resource="#isIngredientOf"/>
+        <rdfs:domain rdf:resource="#Food"/>
+        <rdfs:range rdf:resource="#Food"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#hasSpiciness -->
+
+    <owl:ObjectProperty rdf:about="#hasSpiciness">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:range rdf:resource="#Spiciness"/>
+        <rdfs:comment xml:lang="en"
+            >A property created to be used with the ValuePartition - Spiciness.</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#hasTopping -->
+
+    <owl:ObjectProperty rdf:about="#hasTopping">
+        <rdf:type rdf:resource="&owl;InverseFunctionalProperty"/>
+        <rdfs:comment xml:lang="en"
+            >Note that hasTopping is inverse functional because isToppingOf is functional</rdfs:comment>
+        <rdfs:domain rdf:resource="#Pizza"/>
+        <rdfs:subPropertyOf rdf:resource="#hasIngredient"/>
+        <rdfs:range rdf:resource="#PizzaTopping"/>
+        <owl:inverseOf rdf:resource="#isToppingOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#isBaseOf -->
+
+    <owl:ObjectProperty rdf:about="#isBaseOf">
+        <rdf:type rdf:resource="&owl;InverseFunctionalProperty"/>
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:range rdf:resource="#Pizza"/>
+        <rdfs:domain rdf:resource="#PizzaBase"/>
+        <rdfs:subPropertyOf rdf:resource="#isIngredientOf"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#isIngredientOf -->
+
+    <owl:ObjectProperty rdf:about="#isIngredientOf">
+        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+        <rdfs:domain rdf:resource="#Food"/>
+        <rdfs:comment xml:lang="en"
+            >The inverse property tree to hasIngredient - all subproperties and attributes of the properties should reflect those under hasIngredient.</rdfs:comment>
+        <rdfs:range rdf:resource="#Food"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#isToppingOf -->
+
+    <owl:ObjectProperty rdf:about="#isToppingOf">
+        <rdf:type rdf:resource="&owl;FunctionalProperty"/>
+        <rdfs:subPropertyOf rdf:resource="#isIngredientOf"/>
+        <rdfs:comment xml:lang="en"
+            >Any given instance of topping should only be added to a single pizza (no cheap half-measures on our pizzas)</rdfs:comment>
+        <rdfs:domain rdf:resource="#PizzaTopping"/>
+        <rdfs:range rdf:resource="#Pizza"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#American -->
+
+    <owl:Class rdf:about="#American">
+        <rdfs:label xml:lang="pt">Americana</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#PeperoniSausageTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="#America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#AmericanHot -->
+
+    <owl:Class rdf:about="#AmericanHot">
+        <rdfs:label xml:lang="pt"
+            >AmericanaPicante</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#HotGreenPepperTopping"/>
+                            <rdf:Description rdf:about="#JalapenoPepperTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#PeperoniSausageTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="#America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#JalapenoPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HotGreenPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#AnchoviesTopping -->
+
+    <owl:Class rdf:about="#AnchoviesTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeAnchovies</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#FishTopping"/>
+        <owl:disjointWith rdf:resource="#PrawnsTopping"/>
+        <owl:disjointWith rdf:resource="#MixedSeafoodTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ArtichokeTopping -->
+
+    <owl:Class rdf:about="#ArtichokeTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeArtichoke</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#AsparagusTopping -->
+
+    <owl:Class rdf:about="#AsparagusTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeAspargos</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Cajun -->
+
+    <owl:Class rdf:about="#Cajun">
+        <rdfs:label xml:lang="pt">Cajun</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TobascoPepperSauce"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PrawnsTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#TobascoPepperSauce"/>
+                            <rdf:Description rdf:about="#PeperonataTopping"/>
+                            <rdf:Description rdf:about="#OnionTopping"/>
+                            <rdf:Description rdf:about="#PrawnsTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#Mushroom"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Caprina"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#Capricciosa"/>
+        <owl:disjointWith rdf:resource="#FourSeasons"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#CajunSpiceTopping -->
+
+    <owl:Class rdf:about="#CajunSpiceTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCajun</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#HerbSpiceTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#CaperTopping -->
+
+    <owl:Class rdf:about="#CaperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCaper</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#TomatoTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#PepperTopping"/>
+        <owl:disjointWith rdf:resource="#RocketTopping"/>
+        <owl:disjointWith rdf:resource="#OliveTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Capricciosa -->
+
+    <owl:Class rdf:about="#Capricciosa">
+        <rdfs:label xml:lang="pt">Capricciosa</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="#HamTopping"/>
+                            <rdf:Description rdf:about="#PeperonataTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#CaperTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Caprina -->
+
+    <owl:Class rdf:about="#Caprina">
+        <rdfs:label xml:lang="pt">Caprina</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GoatsCheeseTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#SundriedTomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#GoatsCheeseTopping"/>
+                            <rdf:Description rdf:about="#SundriedTomatoTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#Capricciosa"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#Mushroom"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#CheeseTopping -->
+
+    <owl:Class rdf:about="#CheeseTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeQueijo</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#CheeseyPizza -->
+
+    <owl:Class rdf:about="#CheeseyPizza">
+        <rdfs:label xml:lang="pt">PizzaComQueijo</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="#CheeseTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that has at least 1 cheese topping.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#CheeseyVegetableTopping -->
+
+    <owl:Class rdf:about="#CheeseyVegetableTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeQueijoComVegetais</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:comment xml:lang="en"
+            >This class will be inconsistent. This is because we have given it 2 disjoint parents, which means it could never have any members (as nothing can simultaneously be a CheeseTopping and a VegetableTopping). NB Called ProbeInconsistentTopping in the ProtegeOWL Tutorial.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ChickenTopping -->
+
+    <owl:Class rdf:about="#ChickenTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeFrango</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#HamTopping"/>
+        <owl:disjointWith rdf:resource="#HotSpicedBeefTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Country -->
+
+    <owl:Class rdf:about="#Country">
+        <rdfs:label xml:lang="pt">Pais</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#DomainConcept"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#America"/>
+                            <rdf:Description rdf:about="#Italy"/>
+                            <rdf:Description rdf:about="#Germany"/>
+                            <rdf:Description rdf:about="#England"/>
+                            <rdf:Description rdf:about="#France"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >A class that is equivalent to the set of individuals that are described in the enumeration - ie Countries can only be either America, England, France, Germany or Italy and nothing else. Note that these individuals have been asserted to be allDifferent from each other.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#DeepPanBase -->
+
+    <owl:Class rdf:about="#DeepPanBase">
+        <rdfs:label xml:lang="pt">BaseEspessa</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaBase"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#DomainConcept -->
+
+    <owl:Class rdf:about="#DomainConcept">
+        <owl:disjointWith rdf:resource="#ValuePartition"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Fiorentina -->
+
+    <owl:Class rdf:about="#Fiorentina">
+        <rdfs:label xml:lang="pt">Fiorentina</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#SpinachTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#SpinachTopping"/>
+                            <rdf:Description rdf:about="#ParmesanTopping"/>
+                            <rdf:Description rdf:about="#GarlicTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#FishTopping -->
+
+    <owl:Class rdf:about="#FishTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePeixe</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Food -->
+
+    <owl:Class rdf:about="#Food">
+        <rdfs:subClassOf rdf:resource="#DomainConcept"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#FourCheesesTopping -->
+
+    <owl:Class rdf:about="#FourCheesesTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaQuatroQueijos</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#FourSeasons -->
+
+    <owl:Class rdf:about="#FourSeasons">
+        <rdfs:label xml:lang="pt">QuatroQueijos</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#PeperoniSausageTopping"/>
+                            <rdf:Description rdf:about="#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="#CaperTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#MushroomTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Caprina"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Mushroom"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#Capricciosa"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#FruitTopping -->
+
+    <owl:Class rdf:about="#FruitTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeFrutas</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#FruttiDiMare -->
+
+    <owl:Class rdf:about="#FruttiDiMare">
+        <rdfs:label xml:lang="pt">FrutosDoMar</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MixedSeafoodTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MixedSeafoodTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#GarlicTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#GarlicTopping -->
+
+    <owl:Class rdf:about="#GarlicTopping">
+        <rdfs:label xml:lang="pt">CoberturaDeAlho</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#CaperTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#PepperTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#OliveTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#RocketTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#TomatoTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Giardiniera -->
+
+    <owl:Class rdf:about="#Giardiniera">
+        <rdfs:label xml:lang="pt">Giardiniera</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#SlicedTomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#LeekTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#MushroomTopping"/>
+                            <rdf:Description rdf:about="#LeekTopping"/>
+                            <rdf:Description rdf:about="#SlicedTomatoTopping"/>
+                            <rdf:Description rdf:about="#PetitPoisTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#PeperonataTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PetitPoisTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#GoatsCheeseTopping -->
+
+    <owl:Class rdf:about="#GoatsCheeseTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeQueijoDeCabra</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#ParmesanTopping"/>
+        <owl:disjointWith rdf:resource="#GorgonzolaTopping"/>
+        <owl:disjointWith rdf:resource="#FourCheesesTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#GorgonzolaTopping -->
+
+    <owl:Class rdf:about="#GorgonzolaTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeGorgonzola</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#ParmesanTopping"/>
+        <owl:disjointWith rdf:resource="#FourCheesesTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#GreenPepperTopping -->
+
+    <owl:Class rdf:about="#GreenPepperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePimentaoVerde</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PepperTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#HamTopping -->
+
+    <owl:Class rdf:about="#HamTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePresunto</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#HotSpicedBeefTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#HerbSpiceTopping -->
+
+    <owl:Class rdf:about="#HerbSpiceTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeErvas</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+        <owl:disjointWith rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Hot -->
+
+    <owl:Class rdf:about="#Hot">
+        <rdfs:label xml:lang="pt">Picante</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Spiciness"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#HotGreenPepperTopping -->
+
+    <owl:Class rdf:about="#HotGreenPepperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePimentaoVerdePicante</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#GreenPepperTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#HotSpicedBeefTopping -->
+
+    <owl:Class rdf:about="#HotSpicedBeefTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeBifePicante</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#IceCream -->
+
+    <owl:Class rdf:about="#IceCream">
+        <rdfs:label xml:lang="pt">Sorvete</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#FruitTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#Food"/>
+        <owl:disjointWith rdf:resource="#PizzaBase"/>
+        <owl:disjointWith rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#Pizza"/>
+        <rdfs:comment xml:lang="en"
+            >A class to demonstrate mistakes made with setting a property domain. The property hasTopping has a domain of Pizza. This means that the reasoner can infer that all individuals using the hasTopping property must be of type Pizza. Because of the restriction on this class, all members of IceCream must use the hasTopping property, and therefore must also be members of Pizza. However, Pizza and IceCream are disjoint, so this causes an inconsistency. If they were not disjoint, IceCream would be inferred to be a subclass of Pizza.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#InterestingPizza -->
+
+    <owl:Class rdf:about="#InterestingPizza">
+        <rdfs:label xml:lang="pt"
+            >PizzaInteressante</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:minCardinality rdf:datatype="&xsd;nonNegativeInteger">3</owl:minCardinality>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that has at least 3 toppings. Note that this is a cardinality constraint on the hasTopping property and NOT a qualified cardinality constraint (QCR). A QCR would specify from which class the members in this relationship must be. eg has at least 3 toppings from PizzaTopping. This is currently not supported in OWL.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#JalapenoPepperTopping -->
+
+    <owl:Class rdf:about="#JalapenoPepperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeJalapeno</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#PepperTopping"/>
+        <owl:disjointWith rdf:resource="#GreenPepperTopping"/>
+        <owl:disjointWith rdf:resource="#SweetPepperTopping"/>
+        <owl:disjointWith rdf:resource="#PeperonataTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#LaReine -->
+
+    <owl:Class rdf:about="#LaReine">
+        <rdfs:label xml:lang="pt">LaReine</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#MushroomTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#HamTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#LeekTopping -->
+
+    <owl:Class rdf:about="#LeekTopping">
+        <rdfs:label xml:lang="pt">CoberturaDeLeek</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Margherita -->
+
+    <owl:Class rdf:about="#Margherita">
+        <rdfs:label xml:lang="pt">Margherita</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#MeatTopping -->
+
+    <owl:Class rdf:about="#MeatTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCarne</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#MeatyPizza -->
+
+    <owl:Class rdf:about="#MeatyPizza">
+        <rdfs:label xml:lang="pt">PizzaDeCarne</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="#MeatTopping"/>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that has at least one meat topping</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Medium -->
+
+    <owl:Class rdf:about="#Medium">
+        <rdfs:label xml:lang="pt">Media</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Spiciness"/>
+        <owl:disjointWith rdf:resource="#Hot"/>
+        <owl:disjointWith rdf:resource="#Mild"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Mild -->
+
+    <owl:Class rdf:about="#Mild">
+        <rdfs:label xml:lang="pt">NaoPicante</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Spiciness"/>
+        <owl:disjointWith rdf:resource="#Hot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#MixedSeafoodTopping -->
+
+    <owl:Class rdf:about="#MixedSeafoodTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeFrutosDoMarMistos</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#FishTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#MozzarellaTopping -->
+
+    <owl:Class rdf:about="#MozzarellaTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeMozzarella</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#ParmesanTopping"/>
+        <owl:disjointWith rdf:resource="#FourCheesesTopping"/>
+        <owl:disjointWith rdf:resource="#GoatsCheeseTopping"/>
+        <owl:disjointWith rdf:resource="#GorgonzolaTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Mushroom -->
+
+    <owl:Class rdf:about="#Mushroom">
+        <rdfs:label xml:lang="pt">Cogumelo</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MushroomTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#Capricciosa"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#MushroomTopping -->
+
+    <owl:Class rdf:about="#MushroomTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCogumelo</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#NamedPizza -->
+
+    <owl:Class rdf:about="#NamedPizza">
+        <rdfs:label xml:lang="pt">PizzaComUmNome</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Pizza"/>
+        <rdfs:comment xml:lang="en"
+            >A pizza that can be found on a pizza menu</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Napoletana -->
+
+    <owl:Class rdf:about="#Napoletana">
+        <rdfs:label xml:lang="pt">Napoletana</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#CaperTopping"/>
+                            <rdf:Description rdf:about="#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#NonVegetarianPizza -->
+
+    <owl:Class rdf:about="#NonVegetarianPizza">
+        <rdfs:label xml:lang="pt"
+            >PizzaNaoVegetariana</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="#VegetarianPizza"/>
+                    </owl:Class>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:disjointWith rdf:resource="#VegetarianPizza"/>
+        <rdfs:comment xml:lang="en"
+            >Any Pizza that is not a VegetarianPizza</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#NutTopping -->
+
+    <owl:Class rdf:about="#NutTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCastanha</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#FruitTopping"/>
+        <owl:disjointWith rdf:resource="#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#OliveTopping -->
+
+    <owl:Class rdf:about="#OliveTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeAzeitona</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#TomatoTopping"/>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#OnionTopping -->
+
+    <owl:Class rdf:about="#OnionTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCebola</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ParmaHamTopping -->
+
+    <owl:Class rdf:about="#ParmaHamTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePrezuntoParma</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#HamTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Parmense -->
+
+    <owl:Class rdf:about="#Parmense">
+        <rdfs:label xml:lang="pt">Parmense</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#HamTopping"/>
+                            <rdf:Description rdf:about="#ParmesanTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#AsparagusTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#AsparagusTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ParmesanTopping -->
+
+    <owl:Class rdf:about="#ParmesanTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeParmesao</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#FourCheesesTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PeperonataTopping -->
+
+    <owl:Class rdf:about="#PeperonataTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaPeperonata</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#PepperTopping"/>
+        <owl:disjointWith rdf:resource="#SweetPepperTopping"/>
+        <owl:disjointWith rdf:resource="#GreenPepperTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PeperoniSausageTopping -->
+
+    <owl:Class rdf:about="#PeperoniSausageTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCalabreza</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#HamTopping"/>
+        <owl:disjointWith rdf:resource="#HotSpicedBeefTopping"/>
+        <owl:disjointWith rdf:resource="#ChickenTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PepperTopping -->
+
+    <owl:Class rdf:about="#PepperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePimentao</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#RocketTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#OliveTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#TomatoTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PetitPoisTopping -->
+
+    <owl:Class rdf:about="#PetitPoisTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaPetitPois</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PineKernels -->
+
+    <owl:Class rdf:about="#PineKernels">
+        <rdfs:label xml:lang="pt"
+            >CoberturaPineKernels</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#NutTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Pizza -->
+
+    <owl:Class rdf:about="#Pizza">
+        <rdfs:label xml:lang="en">Pizza</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasBase"/>
+                <owl:someValuesFrom rdf:resource="#PizzaBase"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#Food"/>
+        <owl:disjointWith rdf:resource="#PizzaTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PizzaBase -->
+
+    <owl:Class rdf:about="#PizzaBase">
+        <rdfs:label xml:lang="pt">BaseDaPizza</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Food"/>
+        <owl:disjointWith rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#Pizza"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PizzaTopping -->
+
+    <owl:Class rdf:about="#PizzaTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDaPizza</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#Food"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PolloAdAstra -->
+
+    <owl:Class rdf:about="#PolloAdAstra">
+        <rdfs:label xml:lang="pt">PolloAdAstra</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#CajunSpiceTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#RedOnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#SweetPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#RedOnionTopping"/>
+                            <rdf:Description rdf:about="#CajunSpiceTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#SweetPepperTopping"/>
+                            <rdf:Description rdf:about="#ChickenTopping"/>
+                            <rdf:Description rdf:about="#GarlicTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ChickenTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PrawnsTopping -->
+
+    <owl:Class rdf:about="#PrawnsTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCamarao</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#FishTopping"/>
+        <owl:disjointWith rdf:resource="#MixedSeafoodTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#PrinceCarlo -->
+
+    <owl:Class rdf:about="#PrinceCarlo">
+        <rdfs:label xml:lang="pt"
+            >CoberturaPrinceCarlo</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#LeekTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#RosemaryTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#ParmesanTopping"/>
+                            <rdf:Description rdf:about="#LeekTopping"/>
+                            <rdf:Description rdf:about="#RosemaryTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#Fiorentina"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Veneziana"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#Parmense"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#LaReine"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="#Capricciosa"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#QuattroFormaggi -->
+
+    <owl:Class rdf:about="#QuattroFormaggi">
+        <rdfs:label xml:lang="pt">QuatroQueijos</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#FourCheesesTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#FourCheesesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#RealItalianPizza -->
+
+    <owl:Class rdf:about="#RealItalianPizza">
+        <rdfs:label xml:lang="pt"
+            >PizzaItalianaReal</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                        <owl:hasValue rdf:resource="#Italy"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasBase"/>
+                <owl:allValuesFrom rdf:resource="#ThinAndCrispyBase"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en"
+            >This defined class has conditions that are part of the definition: ie any Pizza that has the country of origin, Italy is a RealItalianPizza. It also has conditions that merely describe the members - that all RealItalianPizzas must only have ThinAndCrispy bases. In essence, all pizzas from Italy must have ThinAndCrispy bases.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#RedOnionTopping -->
+
+    <owl:Class rdf:about="#RedOnionTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeCebolaVermelha</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#OnionTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#RocketTopping -->
+
+    <owl:Class rdf:about="#RocketTopping">
+        <rdfs:label xml:lang="pt">CoberturaRocket</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#OliveTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#TomatoTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Rosa -->
+
+    <owl:Class rdf:about="#Rosa">
+        <rdfs:label xml:lang="pt">Rosa</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#GorgonzolaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GorgonzolaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#RosemaryTopping -->
+
+    <owl:Class rdf:about="#RosemaryTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaRosemary</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#HerbSpiceTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#CajunSpiceTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SauceTopping -->
+
+    <owl:Class rdf:about="#SauceTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaEmMolho</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#NutTopping"/>
+        <owl:disjointWith rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+        <owl:disjointWith rdf:resource="#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="#FruitTopping"/>
+        <owl:disjointWith rdf:resource="#VegetableTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Siciliana -->
+
+    <owl:Class rdf:about="#Siciliana">
+        <rdfs:label xml:lang="pt">Siciliana</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ArtichokeTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#ArtichokeTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#HamTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#GarlicTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SlicedTomatoTopping -->
+
+    <owl:Class rdf:about="#SlicedTomatoTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeTomateFatiado</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#TomatoTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SundriedTomatoTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SloppyGiuseppe -->
+
+    <owl:Class rdf:about="#SloppyGiuseppe">
+        <rdfs:label xml:lang="pt">SloppyGiuseppe</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GreenPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#GreenPepperTopping"/>
+                            <rdf:Description rdf:about="#HotSpicedBeefTopping"/>
+                            <rdf:Description rdf:about="#OnionTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#HotSpicedBeefTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#American"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Soho -->
+
+    <owl:Class rdf:about="#Soho">
+        <rdfs:label xml:lang="pt">Soho</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#RocketTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#GarlicTopping"/>
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#RocketTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#ParmesanTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Spiciness -->
+
+    <owl:Class rdf:about="#Spiciness">
+        <rdfs:label xml:lang="pt">Tempero</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#Hot"/>
+                    <rdf:Description rdf:about="#Mild"/>
+                    <rdf:Description rdf:about="#Medium"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="#ValuePartition"/>
+        <rdfs:comment xml:lang="en"
+            >A ValuePartition that describes only values from Hot, Medium or Mild. NB Subclasses can themselves be divided up into further partitions.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SpicyPizza -->
+
+    <owl:Class rdf:about="#SpicyPizza">
+        <rdfs:label xml:lang="pt">PizzaTemperada</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="#SpicyTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that has a spicy topping is a SpicyPizza</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SpicyPizzaEquivalent -->
+
+    <owl:Class rdf:about="#SpicyPizzaEquivalent">
+        <rdfs:label xml:lang="pt"
+            >PizzaTemperadaEquivalente</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="#hasSpiciness"/>
+                                        <owl:someValuesFrom rdf:resource="#Hot"/>
+                                    </owl:Restriction>
+                                    <rdf:Description rdf:about="#PizzaTopping"/>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >An alternative definition for the SpicyPizza which does away with needing a definition of SpicyTopping and uses a slightly more complicated restriction: Pizzas that have at least one topping that is both a PizzaTopping and has spiciness hot are members of this class.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SpicyTopping -->
+
+    <owl:Class rdf:about="#SpicyTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaTemperada</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasSpiciness"/>
+                        <owl:someValuesFrom rdf:resource="#Hot"/>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#PizzaTopping"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza topping that has spiciness Hot</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SpinachTopping -->
+
+    <owl:Class rdf:about="#SpinachTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeEspinafre</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SultanaTopping -->
+
+    <owl:Class rdf:about="#SultanaTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaSultana</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#FruitTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SundriedTomatoTopping -->
+
+    <owl:Class rdf:about="#SundriedTomatoTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeTomateRessecadoAoSol</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#TomatoTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#SweetPepperTopping -->
+
+    <owl:Class rdf:about="#SweetPepperTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDePimentaoDoce</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PepperTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#GreenPepperTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ThinAndCrispyBase -->
+
+    <owl:Class rdf:about="#ThinAndCrispyBase">
+        <rdfs:label xml:lang="pt"
+            >BaseFinaEQuebradica</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaBase"/>
+        <owl:disjointWith rdf:resource="#DeepPanBase"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ThinAndCrispyPizza -->
+
+    <owl:Class rdf:about="#ThinAndCrispyPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasBase"/>
+                        <owl:allValuesFrom rdf:resource="#ThinAndCrispyBase"/>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#TobascoPepperSauce -->
+
+    <owl:Class rdf:about="#TobascoPepperSauce">
+        <rdfs:label xml:lang="pt"
+            >MolhoTobascoPepper</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#SauceTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#TomatoTopping -->
+
+    <owl:Class rdf:about="#TomatoTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeTomate</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#LeekTopping"/>
+        <owl:disjointWith rdf:resource="#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="#ArtichokeTopping"/>
+        <owl:disjointWith rdf:resource="#OnionTopping"/>
+        <owl:disjointWith rdf:resource="#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="#AsparagusTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#UnclosedPizza -->
+
+    <owl:Class rdf:about="#UnclosedPizza">
+        <rdfs:label xml:lang="pt">PizzaAberta</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <rdfs:comment rdf:datatype="&xsd;string"
+            >An unclosed Pizza cannot be inferred to be either a VegetarianPizza or a NonVegetarianPizza, because it might have other toppings.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#ValuePartition -->
+
+    <owl:Class rdf:about="#ValuePartition">
+        <rdfs:label xml:lang="pt">ValorDaParticao</rdfs:label>
+        <rdfs:comment rdf:datatype="&xsd;string"
+            >A ValuePartition is a pattern that describes a restricted set of classes from which a property can be associated. The parent class is used in restrictions, and the covering axiom means that only members of the subclasses may be used as values. The possible subclasses cannot be extended without updating the ValuePartition class.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetableTopping -->
+
+    <owl:Class rdf:about="#VegetableTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaDeVegetais</rdfs:label>
+        <rdfs:subClassOf rdf:resource="#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="#MeatTopping"/>
+        <owl:disjointWith rdf:resource="#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="#FruitTopping"/>
+        <owl:disjointWith rdf:resource="#CheeseTopping"/>
+        <owl:disjointWith rdf:resource="#FishTopping"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetarianPizza -->
+
+    <owl:Class rdf:about="#VegetarianPizza">
+        <rdfs:label xml:lang="pt"
+            >PizzaVegetariana</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Class>
+                        <owl:complementOf>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="#hasTopping"/>
+                                <owl:someValuesFrom rdf:resource="#MeatTopping"/>
+                            </owl:Restriction>
+                        </owl:complementOf>
+                    </owl:Class>
+                    <rdf:Description rdf:about="#Pizza"/>
+                    <owl:Class>
+                        <owl:complementOf>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="#hasTopping"/>
+                                <owl:someValuesFrom rdf:resource="#FishTopping"/>
+                            </owl:Restriction>
+                        </owl:complementOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that does not have fish topping and does not have meat topping is a VegetarianPizza. Members of this class do not need to have any toppings at all.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetarianPizzaEquivalent1 -->
+
+    <owl:Class rdf:about="#VegetarianPizzaEquivalent1">
+        <rdfs:label xml:lang="pt"
+            >PizzaVegetarianaEquivalente1</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:allValuesFrom rdf:resource="#VegetarianTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >Any pizza that only has vegetarian toppings or no toppings is a VegetarianPizzaEquiv1. Should be inferred to be equivalent to VegetarianPizzaEquiv2.  Not equivalent to VegetarianPizza because PizzaTopping is not covering</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetarianPizzaEquivalent2 -->
+
+    <owl:Class rdf:about="#VegetarianPizzaEquivalent2">
+        <rdfs:label xml:lang="pt"
+            >PizzaVegetarianaEquivalente2</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="#hasTopping"/>
+                        <owl:allValuesFrom>
+                            <owl:Class>
+                                <owl:unionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="#SauceTopping"/>
+                                    <rdf:Description rdf:about="#VegetableTopping"/>
+                                    <rdf:Description rdf:about="#FruitTopping"/>
+                                    <rdf:Description rdf:about="#CheeseTopping"/>
+                                    <rdf:Description rdf:about="#HerbSpiceTopping"/>
+                                    <rdf:Description rdf:about="#NutTopping"/>
+                                </owl:unionOf>
+                            </owl:Class>
+                        </owl:allValuesFrom>
+                    </owl:Restriction>
+                    <rdf:Description rdf:about="#Pizza"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >An alternative to VegetarianPizzaEquiv1 that does not require a definition of VegetarianTopping. Perhaps more difficult to maintain. Not equivalent to VegetarianPizza</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetarianTopping -->
+
+    <owl:Class rdf:about="#VegetarianTopping">
+        <rdfs:label xml:lang="pt"
+            >CoberturaVegetariana</rdfs:label>
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="#PizzaTopping"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#SauceTopping"/>
+                            <rdf:Description rdf:about="#VegetableTopping"/>
+                            <rdf:Description rdf:about="#FruitTopping"/>
+                            <rdf:Description rdf:about="#CheeseTopping"/>
+                            <rdf:Description rdf:about="#HerbSpiceTopping"/>
+                            <rdf:Description rdf:about="#NutTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en"
+            >An example of a covering axiom. VegetarianTopping is equivalent to the union of all toppings in the given axiom. VegetarianToppings can only be Cheese or Vegetable or....etc.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Veneziana -->
+
+    <owl:Class rdf:about="#Veneziana">
+        <rdfs:label xml:lang="pt">Veneziana</rdfs:label>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#PineKernels"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="#CaperTopping"/>
+                            <rdf:Description rdf:about="#PineKernels"/>
+                            <rdf:Description rdf:about="#OliveTopping"/>
+                            <rdf:Description rdf:about="#TomatoTopping"/>
+                            <rdf:Description rdf:about="#SultanaTopping"/>
+                            <rdf:Description rdf:about="#OnionTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf rdf:resource="#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#SultanaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="#Giardiniera"/>
+        <owl:disjointWith rdf:resource="#Rosa"/>
+        <owl:disjointWith rdf:resource="#Margherita"/>
+        <owl:disjointWith rdf:resource="#Siciliana"/>
+        <owl:disjointWith rdf:resource="#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="#Napoletana"/>
+        <owl:disjointWith rdf:resource="#American"/>
+        <owl:disjointWith rdf:resource="#AmericanHot"/>
+        <owl:disjointWith rdf:resource="#Soho"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#Thing -->
+
+    <owl:Class rdf:about="&owl;Thing"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#America -->
+
+    <Country rdf:about="#America">
+        <rdf:type rdf:resource="&owl;Thing"/>
+    </Country>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="#America"/>
+            <rdf:Description rdf:about="#Italy"/>
+            <rdf:Description rdf:about="#Germany"/>
+            <rdf:Description rdf:about="#England"/>
+            <rdf:Description rdf:about="#France"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#England -->
+
+    <owl:Thing rdf:about="#England">
+        <rdf:type rdf:resource="#Country"/>
+    </owl:Thing>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="#America"/>
+            <rdf:Description rdf:about="#Italy"/>
+            <rdf:Description rdf:about="#Germany"/>
+            <rdf:Description rdf:about="#England"/>
+            <rdf:Description rdf:about="#France"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#France -->
+
+    <Country rdf:about="#France">
+        <rdf:type rdf:resource="&owl;Thing"/>
+    </Country>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="#America"/>
+            <rdf:Description rdf:about="#Italy"/>
+            <rdf:Description rdf:about="#Germany"/>
+            <rdf:Description rdf:about="#England"/>
+            <rdf:Description rdf:about="#France"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Germany -->
+
+    <owl:Thing rdf:about="#Germany">
+        <rdf:type rdf:resource="#Country"/>
+    </owl:Thing>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="#America"/>
+            <rdf:Description rdf:about="#Italy"/>
+            <rdf:Description rdf:about="#Germany"/>
+            <rdf:Description rdf:about="#England"/>
+            <rdf:Description rdf:about="#France"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.co-ode.org/ontologies/pizza/pizza.owl#Italy -->
+
+    <owl:Thing rdf:about="#Italy">
+        <rdf:type rdf:resource="#Country"/>
+    </owl:Thing>
+    <rdf:Description>
+        <rdf:type rdf:resource="&owl;AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="#America"/>
+            <rdf:Description rdf:about="#Italy"/>
+            <rdf:Description rdf:about="#Germany"/>
+            <rdf:Description rdf:about="#England"/>
+            <rdf:Description rdf:about="#France"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+</rdf:RDF>

--- a/invoker.ini
+++ b/invoker.ini
@@ -1,6 +1,13 @@
 [ontohub-backend]
+directory = .
 command = bundle exec rails s -p $ONTOHUB_BACKEND_PORT
 port = $ONTOHUB_BACKEND_PORT
 
 [sneakers]
+directory = .
 command = bundle exec rails sneakers:run
+
+[hets-agent]
+sleep = 7
+directory = ../hets-agent/
+command = bin/hets_agent

--- a/lib/hets_agent/analysis_request_collection.rb
+++ b/lib/hets_agent/analysis_request_collection.rb
@@ -12,7 +12,7 @@ module HetsAgent
 
     def initialize(repository_id, commit_sha)
       @commit_sha = commit_sha
-      @repository = RepositoryCompound.find(id: repository_id)
+      @repository = RepositoryCompound.first!(id: repository_id)
       @git = @repository.git
     end
 
@@ -30,25 +30,28 @@ module HetsAgent
 
     protected
 
-    # rubocop:disable Metrics/MethodLength
     def hets_agent_arguments(diff)
-      # rubocop:enable Metrics/MethodLength
       return if diff.deleted_file
 
       file_path = diff.new_path
       return unless file_path
 
-      file_version_id = FileVersion.first!(commit_sha: commit_sha,
-                                           path: file_path).id
+      file_version = FileVersion.first!(commit_sha: commit_sha,
+                                        path: file_path)
+      arguments(file_version)
+    end
 
+    # rubocop:disable Metrics/MethodLength
+    def arguments(file_version)
+      # rubocop:enable Metrics/MethodLength
       {
         action: 'analysis',
         arguments: {
           server_url: Settings.server_url,
           repository_slug: repository.to_param,
           revision: commit_sha,
-          file_path: file_path,
-          file_version_id: file_version_id,
+          file_path: file_version.path,
+          file_version_id: file_version.id,
           url_mappings: url_mappings,
         },
       }

--- a/lib/hets_agent/analysis_request_collection.rb
+++ b/lib/hets_agent/analysis_request_collection.rb
@@ -49,9 +49,15 @@ module HetsAgent
           revision: commit_sha,
           file_path: file_path,
           file_version_id: file_version_id,
-          url_mappings: [],
+          url_mappings: url_mappings,
         },
       }
+    end
+
+    def url_mappings
+      repository.url_mappings.map do |url_mapping|
+        {url_mapping.source => url_mapping.target}
+      end
     end
   end
 end

--- a/lib/hets_agent/analysis_request_collection.rb
+++ b/lib/hets_agent/analysis_request_collection.rb
@@ -35,6 +35,10 @@ module HetsAgent
 
       file_path = diff.new_path
       return unless file_path
+      unless OntohubBackend::Application.config.document_file_extensions.
+          include?(File.extname(file_path))
+        return
+      end
 
       file_version = FileVersion.first!(commit_sha: commit_sha,
                                         path: file_path)

--- a/lib/hets_agent/invoker.rb
+++ b/lib/hets_agent/invoker.rb
@@ -7,30 +7,16 @@ module HetsAgent
     WORKER_QUEUE_NAME =
       "hets #{OntohubBackend::Application.config.hets_version_requirement}"
 
-    attr_reader :connection, :request_collection
+    attr_reader :request_collection
 
     def initialize(request_collection)
       @request_collection = request_collection
-      @connection = Sneakers::CONFIG[:connection]
     end
 
     def call
-      connection.start
-      queue = create_worker_queue(connection)
       request_collection.each do |request|
-        queue.publish(request.to_json)
+        Sneakers.publish(request.to_json, to_queue: WORKER_QUEUE_NAME)
       end
-    ensure
-      connection.close
-    end
-
-    protected
-
-    def create_worker_queue(connection)
-      channel = connection.create_channel
-      channel.queue(WORKER_QUEUE_NAME,
-                    durable: true,
-                    auto_delete: false)
     end
   end
 end

--- a/lib/hets_agent/reanalysis_request_collection.rb
+++ b/lib/hets_agent/reanalysis_request_collection.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module HetsAgent
+  # Builds arguments (a "request") for the HetsAgent application.
+  class ReanalysisRequestCollection < AnalysisRequestCollection
+    include Enumerable
+
+    attr_reader :commit_sha, :file_version, :repository
+
+    delegate :each, to: :requests
+
+    def initialize(file_version)
+      @commit_sha = file_version.commit_sha
+      @file_version = file_version
+      @repository = RepositoryCompound.first!(id: file_version.repository_id)
+    end
+
+    def requests
+      @requests ||= [arguments(file_version)]
+    end
+  end
+end

--- a/lib/importing_documents_reanalyzer.rb
+++ b/lib/importing_documents_reanalyzer.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# If a Document that is imported by another Document is changed, the importing
+# one needs to be analysed again, while importing the newer revision of the
+# imported one.
+# It takes long in a big repository because the git log needs to be walked to
+# the end.
+class ImportingDocumentsReanalyzer
+  attr_reader :commit_sha, :git, :file_path, :file_version, :repository
+
+  def initialize(file_version_id)
+    @file_version = FileVersion.first!(id: file_version_id)
+    @file_path = file_version.path
+    @commit_sha = file_version.commit_sha
+    @repository = RepositoryCompound.first!(id: file_version.repository_id)
+    @git = repository.git
+  end
+
+  def call
+    return :requeue if previous_versions_still_processing?
+    process
+    :done
+  end
+
+  protected
+
+  def previous_versions_still_processing?
+    # TODO: This method can be optimized:
+    # Find the newest commit C that is finished processing for sure.
+    # instead of `ref: commit_sha`, use `ref: "#{C}..#{commit_sha}"
+    # for the git log.
+    unfinished_shas =
+      FileVersion.
+        where(evaluation_state: %w(not_yet_enqueued enqueued processing),
+              repository_id: file_version.repository_id).
+        map(:commit_sha)
+    # Go all the way back to the root commit (this can be optimized)
+    git.log(ref: commit_sha, limit: 0, only_commit_sha: true).any? do |log_sha|
+      unfinished_shas.include?(log_sha)
+    end
+  end
+
+  def process
+    Document.where(file_version_id: file_version.id).each do |document|
+      previous_revision = find_previous_revision(document)
+      next if previous_revision.nil?
+
+      previous_revision.imported_by.each do |importer|
+        Sequel::Model.db.transaction do
+          next if already_analyzed?(importer)
+          reanalyze_importer(importer)
+        end
+      end
+    end
+  end
+
+  def find_previous_revision(document)
+    target_sha = git.log(ref: commit_sha, path: file_path, limit: 2)[1]&.id
+    return nil if target_sha.nil?
+
+    previous_file_version = FileVersion.find(path: file_path,
+                                             commit_sha: target_sha)
+    Document.first(file_version_id: previous_file_version&.id,
+                   kind: document.kind)
+  end
+
+  def already_analyzed?(document)
+    !FileVersion.where(repository_id: repository.id,
+                       commit_sha: commit_sha,
+                       path: document.file_version.path).empty?
+  end
+
+  def reanalyze_importer(importer)
+    new_file_version =
+      FileVersion.create(repository_id: repository.id,
+                         commit_sha: commit_sha,
+                         path: importer.file_version.path)
+    modify_file_version_parents(importer, new_file_version)
+
+    request_collection =
+      HetsAgent::ReanalysisRequestCollection.new(new_file_version)
+    HetsAgent::Invoker.new(request_collection).call
+  end
+
+  # This takes long in a big repository
+  def modify_file_version_parents(document, new_file_version)
+    git.log(ref: range_until_next_change(new_file_version),
+            unsafe_range: true,
+            limit: 0).each do |commit|
+      FileVersionParent.
+        where(last_changed_file_version_id: document.file_version.id,
+              queried_sha: commit.id).
+        update(last_changed_file_version_id: new_file_version.id)
+    end
+  end
+
+  # This does not include the commit of the next change
+  def range_until_next_change(new_file_version)
+    first_newer_sha = next_changing_commit(new_file_version)
+    end_revision = first_newer_sha.nil? ? '' : "#{first_newer_sha}~1"
+
+    # Using the parent-commit-operator "~1" is safe because we inspect an
+    # updated revision of the file. Hence, a previous revision must exist.
+    "#{new_file_version.commit_sha}~1..#{end_revision}"
+  end
+
+  # This takes long in a big repository
+  def next_changing_commit(importer_file_version)
+    git.log(ref: "#{importer_file_version.commit_sha}..",
+            path: importer_file_version.path,
+            unsafe_range: true,
+            limit: 0)[-1]&.id
+  end
+end

--- a/lib/importing_documents_reanalyzer.rb
+++ b/lib/importing_documents_reanalyzer.rb
@@ -60,8 +60,7 @@ class ImportingDocumentsReanalyzer
 
     previous_file_version = FileVersion.find(path: file_path,
                                              commit_sha: target_sha)
-    Document.first(file_version_id: previous_file_version&.id,
-                   kind: document.kind)
+    Document.first(file_version_id: previous_file_version&.id)
   end
 
   def already_analyzed?(document)

--- a/lib/tasks/invoker.rake
+++ b/lib/tasks/invoker.rake
@@ -8,14 +8,14 @@ end
 namespace :invoker do
   desc 'Stops all processes that are using the database'
   task :stop_all do
-    %w(ontohub-backend sneakers).each do |process|
+    %w(ontohub-backend sneakers hets-agent).each do |process|
       system('bundle', 'exec', 'invoker', 'remove', process)
     end
   end
 
   desc 'Starts all processes that are using the database'
   task :start_all do
-    %w(ontohub-backend sneakers).each do |process|
+    %w(ontohub-backend sneakers hets-agent).each do |process|
       system('bundle', 'exec', 'invoker', 'add', process)
     end
   end

--- a/lib/tasks/invoker.rake
+++ b/lib/tasks/invoker.rake
@@ -9,14 +9,14 @@ namespace :invoker do
   desc 'Stops all processes that are using the database'
   task :stop_all do
     %w(ontohub-backend sneakers hets-agent).each do |process|
-      system('bundle', 'exec', 'invoker', 'remove', process)
+      system("bundle exec invoker remove #{process} 1> /dev/null 2> /dev/null")
     end
   end
 
   desc 'Starts all processes that are using the database'
   task :start_all do
     %w(ontohub-backend sneakers hets-agent).each do |process|
-      system('bundle', 'exec', 'invoker', 'add', process)
+      system("bundle exec invoker add #{process} 1> /dev/null 2> /dev/null")
     end
   end
 end

--- a/spec/factories/repository_compound_factory.rb
+++ b/spec/factories/repository_compound_factory.rb
@@ -54,13 +54,14 @@ FactoryBot.define do
       user { create(:user) }
       branch { repository.git.default_branch }
       files { [] }
+      commit_message { generate(:commit_message) }
     end
     skip_create
     initialize_with do
       MultiBlob.new(user: user,
                     repository: repository,
                     branch: branch,
-                    commit_message: generate(:commit_message),
+                    commit_message: commit_message,
                     files: files).save
     end
   end
@@ -74,6 +75,7 @@ FactoryBot.define do
       encoding { 'plain' }
       branch { nil } # will be delegated to factory :additional_commit
       user { nil } # will be delegated to factory :additional_commit
+      commit_message { nil } # will be delegated to factory :additional_commit
     end
     skip_create
     initialize_with do
@@ -84,6 +86,7 @@ FactoryBot.define do
       options = {repository: repository, files: files}
       options[:branch] = branch if branch
       options[:user] = user if user
+      options[:commit_message] = commit_message if commit_message
       create(:additional_commit, **options)
     end
   end

--- a/spec/factories/repository_compound_factory.rb
+++ b/spec/factories/repository_compound_factory.rb
@@ -29,8 +29,10 @@ FactoryBot.define do
 
   trait :not_empty do
     transient do
+      commit_count { 1 }
       git do
         create(:git, :with_commits,
+               commit_count: commit_count,
                path: RepositoryCompound.git_directory.
                  join("#{repository.to_param}.git"))
       end

--- a/spec/jobs/post_process_hets_job_spec.rb
+++ b/spec/jobs/post_process_hets_job_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PostProcessHetsJob, type: :job do
+  let(:file_version) { create(:file_version) }
+  let(:importing_documents_reanalyzer) { double(:reanalyzer) }
+  let(:post_processing_result) { :done }
+  let(:action) { 'analysis' }
+
+  let(:original_job_message) do
+    {'action' => action,
+     'arguments' => {'file_version_id' => file_version.id}}
+  end
+  let(:job_message) { [result, original_job_message.to_json] }
+
+  before do
+    # Don't wait in the test
+    allow_any_instance_of(PostProcessHetsJob).to receive(:sleep)
+
+    # Don't call the actual post-processing
+    allow(ImportingDocumentsReanalyzer).
+      to receive(:new).
+      with(file_version.id).
+      and_return(importing_documents_reanalyzer)
+
+    allow(importing_documents_reanalyzer).
+      to receive(:call).
+      and_return(post_processing_result)
+  end
+
+  context 'result: no success' do
+    let(:result) { 'failure' }
+
+    it 'returns nil' do
+      expect(PostProcessHetsJob.new.perform(*job_message)).to be(nil)
+    end
+
+    it 'does not enqueue another job' do
+      expect { PostProcessHetsJob.new.perform(*job_message) }.
+        not_to have_enqueued_job
+    end
+  end
+
+  context 'result: success' do
+    let(:result) { 'success' }
+
+    context 'unkown action' do
+      let(:action) { 'unknown' }
+
+      it 'returns nil' do
+        expect(PostProcessHetsJob.new.perform(*job_message)).to be(nil)
+      end
+
+      it 'does not enqueue another job' do
+        expect { PostProcessHetsJob.new.perform(*job_message) }.
+          not_to have_enqueued_job
+      end
+    end
+
+    context 'action: analysis' do
+      context 'done' do
+        it 'returns the post_processing_result' do
+          expect(PostProcessHetsJob.new.perform(*job_message)).
+            to eq(post_processing_result)
+        end
+
+        it 'does not sleep' do
+          expect_any_instance_of(PostProcessHetsJob).not_to receive(:sleep)
+          PostProcessHetsJob.new.perform(*job_message)
+        end
+
+        it 'does not enqueue another job' do
+          expect { PostProcessHetsJob.new.perform(*job_message) }.
+            not_to have_enqueued_job
+        end
+
+        it 'calls the ImportingDocumentsReanalyzer' do
+          PostProcessHetsJob.new.perform(*job_message)
+          expect(importing_documents_reanalyzer).to have_received(:call)
+        end
+      end
+
+      context 'need to requeue' do
+        let(:post_processing_result) { :requeue }
+
+        it 'returns the post_processing_result' do
+          expect(PostProcessHetsJob.new.perform(*job_message)).
+            to eq(post_processing_result)
+        end
+
+        it 'sleeps' do
+          expect_any_instance_of(PostProcessHetsJob).to receive(:sleep)
+          PostProcessHetsJob.new.perform(*job_message)
+        end
+
+        it 'enqueues the same job again' do
+          expect { PostProcessHetsJob.new.perform(*job_message) }.
+            to have_enqueued_job.
+            with(*job_message).
+            on_queue('post_process_hets')
+        end
+
+        it 'calls the ImportingDocumentsReanalyzer' do
+          PostProcessHetsJob.new.perform(*job_message)
+          expect(importing_documents_reanalyzer).to have_received(:call)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hets_agent/analysis_request_collection_spec.rb
+++ b/spec/lib/hets_agent/analysis_request_collection_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe HetsAgent::AnalysisRequestCollection do
   let(:repository) { create(:repository_compound, :not_empty) }
+  let!(:url_mappings) { create_list(:url_mapping, 2, repository: repository) }
   let(:files_count) { 5 }
   let(:document_files_count) { 3 }
   let(:file_paths) do
@@ -55,10 +56,15 @@ RSpec.describe HetsAgent::AnalysisRequestCollection do
       subject.each do |request|
         expect(request).
           to include(action: 'analysis',
-                     arguments: include(server_url: Settings.server_url,
-                                        repository_slug: repository.to_param,
-                                        revision: commit_sha,
-                                        url_mappings: []))
+                     arguments:
+                       include(server_url: Settings.server_url,
+                               repository_slug: repository.to_param,
+                               revision: commit_sha,
+                               url_mappings:
+                                 match_array([{url_mappings[0].source =>
+                                               url_mappings[0].target},
+                                              {url_mappings[1].source =>
+                                               url_mappings[1].target}])))
       end
     end
   end

--- a/spec/lib/hets_agent/analysis_request_collection_spec.rb
+++ b/spec/lib/hets_agent/analysis_request_collection_spec.rb
@@ -2,10 +2,20 @@
 
 RSpec.describe HetsAgent::AnalysisRequestCollection do
   let(:repository) { create(:repository_compound, :not_empty) }
-  let(:files_count) { 2 }
+  let(:files_count) { 5 }
+  let(:document_files_count) { 3 }
+  let(:file_paths) do
+    (0..files_count - 1).map do |i|
+      if i < document_files_count
+        "#{generate(:filepath)}.dol"
+      else
+        "#{generate(:filepath)}.txt"
+      end
+    end
+  end
   let(:commit_sha) do
-    files = (1..files_count).map do
-      {path: generate(:filepath),
+    files = (0..files_count - 1).map do |i|
+      {path: file_paths[i],
        content: generate(:content),
        encoding: 'plain',
        action: 'create'}
@@ -20,8 +30,9 @@ RSpec.describe HetsAgent::AnalysisRequestCollection do
   end
 
   context 'requests' do
-    it 'as many requests exist as files were touched' do
-      expect(subject.requests.length).to eq(files_count)
+    it 'as many requests exist as document files were touched' do
+      expect(subject.requests.length).
+        to eq(document_files_count)
     end
 
     it 'contains one request for every touched file' do
@@ -37,7 +48,7 @@ RSpec.describe HetsAgent::AnalysisRequestCollection do
       end.
         to change { file_versions.length }.
         from(files_count).
-        to(0)
+        to(files_count - document_files_count)
     end
 
     it 'has the correct request format except for file_path/file_version_id' do

--- a/spec/lib/hets_agent/reanalysis_request_collection_spec.rb
+++ b/spec/lib/hets_agent/reanalysis_request_collection_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe HetsAgent::ReanalysisRequestCollection do
+  let(:repository) { create(:repository_compound, :not_empty) }
+  let(:file_version) { create(:file_version, repository: repository) }
+
+  subject do
+    HetsAgent::ReanalysisRequestCollection.new(file_version)
+  end
+
+  context 'requests' do
+    it 'contains exactly one request' do
+      expect(subject.requests.length).to eq(1)
+    end
+
+    it 'contains one request for every touched file' do
+      correct_arguments = subject.map do |request|
+        request[:arguments][:file_version_id] == file_version.id &&
+          request[:arguments][:file_path] == file_version.path &&
+          request[:arguments][:revision] == file_version.commit_sha
+      end
+      expect(correct_arguments).to eq([true])
+    end
+
+    it 'has the correct request format except for file_path/file_version_id' do
+      subject.each do |request|
+        expect(request).
+          to include(action: 'analysis',
+                     arguments: include(server_url: Settings.server_url,
+                                        repository_slug: repository.to_param,
+                                        url_mappings: []))
+      end
+    end
+  end
+
+  context 'each' do
+    it 'is delegated to requests' do
+      direct = []
+      indirect = []
+      subject.each { |request| direct << request }
+      subject.requests.each { |request| indirect << request }
+      expect(direct).to eq(indirect)
+    end
+  end
+end

--- a/spec/lib/importing_documents_reanalyzer_spec.rb
+++ b/spec/lib/importing_documents_reanalyzer_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe ImportingDocumentsReanalyzer do
+  let(:repository) { create(:repository_compound) }
+  let(:file_version) do
+    create(:file_version,
+           evaluation_state: 'finished_successfully',
+           repository: repository)
+  end
+
+  subject { ImportingDocumentsReanalyzer.new(file_version.id) }
+
+  context 'return value when there are older FileVersions' do
+    before do
+      allow_any_instance_of(Gitlab::Git::Wrapper).
+        to receive(:log).
+        with(include(ref: file_version.commit_sha, only_commit_sha: true)).
+        and_return([older_file_version.commit_sha,
+                    file_version.commit_sha])
+
+      allow(subject).to receive(:process)
+    end
+
+    %w(not_yet_enqueued enqueued processing).each do |state|
+      context "with evaluation_state #{state}" do
+        let(:older_file_version) do
+          create(:file_version, evaluation_state: state, repository: repository)
+        end
+
+        it 'returns :requeue' do
+          expect(subject.call).to eq(:requeue)
+        end
+      end
+    end
+
+    %w(finished_successfully finished_unsuccessfully).each do |state|
+      context "with evaluation_state #{state}" do
+        let(:older_file_version) do
+          create(:file_version, evaluation_state: state, repository: repository)
+        end
+
+        it 'returns :done' do
+          expect(subject.call).to eq(:done)
+        end
+      end
+    end
+  end
+
+  context 'detecting an import' do
+    before do
+      # This is called by MultiBlob#save, which is called by the
+      # :additional_commit factory. It needs to be perfomed inline.
+      allow(ProcessCommitJob).to receive(:perform_later) do |*args|
+        ProcessCommitJob.new.perform(*args)
+      end
+      # However, nothing should be published to RabbitMQ. So, stub it:
+      stub = double(:invoker)
+      allow(HetsAgent::Invoker).to receive(:new).and_return(stub)
+      allow(stub).to receive(:call)
+    end
+
+    let(:repository) { create(:repository_compound) }
+    let(:git) { repository.git }
+    let(:file_version_creator) do
+      lambda do |path = nil|
+        options = {repository: repository,
+                   files: [{path: path ? path : generate(:filepath),
+                            content: generate(:content),
+                            encoding: 'plain',
+                            action: path ? 'update' : 'create'}]}
+        commit_sha = create(:additional_commit, options)
+
+        file_version = FileVersion.first(commit_sha: commit_sha)
+        file_version.evaluation_state = 'finished_successfully'
+        file_version.save
+        file_version
+      end
+    end
+
+    let!(:imported_file_version) { file_version_creator.call }
+    let!(:imported_document) do
+      create(:document, file_version: imported_file_version)
+    end
+
+    let!(:old_file_version) { file_version_creator.call }
+    let!(:old_document) { create(:document, file_version: old_file_version) }
+
+    let!(:importing_file_version1) { file_version_creator.call }
+    let!(:importing_document1) do
+      create(:document, file_version: importing_file_version1)
+    end
+
+    let!(:importing_file_version2) { file_version_creator.call }
+    let!(:importing_document2) do
+      create(:document, file_version: importing_file_version2)
+    end
+
+    let!(:unrelated_document) do
+      create(:document, file_version: file_version_creator.call)
+    end
+
+    let!(:updated_file_version) do
+      file_version_creator.call(old_file_version.path)
+    end
+    let!(:updated_document) do
+      create(:document, file_version: updated_file_version)
+    end
+
+    let!(:updated_unrelated_file_version) do
+      file_version_creator.call(unrelated_document.file_version.path)
+    end
+    let!(:updated_unrelated_document) do
+      create(:document, file_version: updated_unrelated_file_version)
+    end
+
+    let(:hets_agent_invoker) { double(:invoker) }
+
+    before do
+      create(:document_link, source: old_document, target: imported_document)
+      create(:document_link, source: importing_document1, target: old_document)
+      create(:document_link, source: importing_document2, target: old_document)
+
+      allow(HetsAgent::ReanalysisRequestCollection).
+        to receive(:new).and_call_original
+
+      allow(HetsAgent::Invoker).to receive(:new).and_return(hets_agent_invoker)
+      allow(hets_agent_invoker).to receive(:call)
+
+      subject.call
+    end
+
+    context 'when there is no import' do
+      let(:file_version) { updated_unrelated_document.file_version }
+
+      it 'does not enqueue jobs' do
+        expect(hets_agent_invoker).not_to have_received(:call)
+      end
+    end
+
+    context 'when there is no previous version' do
+      let(:file_version) { old_file_version }
+
+      it 'does not enqueue jobs' do
+        expect(hets_agent_invoker).not_to have_received(:call)
+      end
+    end
+
+    context 'when there is a previous version' do
+      let(:file_version) { updated_file_version }
+
+      it 'creates new FileVersions for each importing document file' do
+        [importing_file_version1,
+         importing_file_version2].each do |importing_file_version|
+          found = FileVersion.first(repository_id: repository.id,
+                                    commit_sha: file_version.commit_sha,
+                                    path: importing_file_version.path)
+          expect(found).not_to be(nil)
+        end
+      end
+
+      it 'removes the FileVersionParents of each importing document file' do
+        [updated_file_version,
+         updated_unrelated_file_version].map(&:commit_sha).each do |commit_sha|
+          [importing_file_version1,
+           importing_file_version2].each do |importing_file_version|
+            found = FileVersionParent.
+              first(last_changed_file_version_id: importing_file_version.id,
+                    queried_sha: commit_sha)
+            expect(found).to be(nil)
+          end
+        end
+      end
+
+      it 'creates FileVersionParents of each importing document file' do
+        [updated_file_version,
+         updated_unrelated_file_version].map(&:commit_sha).each do |commit_sha|
+          [importing_file_version1,
+           importing_file_version2].each do |importing_file_version|
+            new_file_version = FileVersion.
+              first(repository_id: repository.id,
+                    commit_sha: file_version.commit_sha,
+                    path: importing_file_version.path)
+            found = FileVersionParent.
+              first(last_changed_file_version_id: new_file_version.id,
+                    queried_sha: commit_sha)
+            expect(found).not_to be(nil)
+          end
+        end
+      end
+
+      it 'creates a request for re-analysis for every importing document' do
+        [importing_file_version1,
+         importing_file_version2].each do |importing_file_version|
+          expect(HetsAgent::ReanalysisRequestCollection).
+            to have_received(:new).
+            with(eq(FileVersion.first(repository_id: repository.id,
+                                      commit_sha: file_version.commit_sha,
+                                      path: importing_file_version.path)))
+        end
+      end
+
+      it 'enqueues jobs for each importing document' do
+        expect(hets_agent_invoker).to have_received(:call).twice
+      end
+    end
+  end
+end

--- a/spec/models/repository_compound_spec.rb
+++ b/spec/models/repository_compound_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe RepositoryCompound do
+  subject { create(:repository_compound) }
+
+  context 'class methods' do
+    %i(find first).each do |method|
+      context method do
+        it 'finds the repository' do
+          expect(RepositoryCompound.public_send(method, slug: subject.slug)).
+            to eq(subject)
+        end
+
+        it 'returns nil if not found' do
+          expect(RepositoryCompound.public_send(method, id: -1)).
+            to be(nil)
+        end
+      end
+    end
+
+    context 'first!' do
+      it 'finds the repository' do
+        expect(RepositoryCompound.first!(id: subject.id)).to eq(subject)
+      end
+
+      it 'raises an error if not found' do
+        expect { RepositoryCompound.first!(id: -1) }.
+          to raise_error(Sequel::NoMatchingRow)
+      end
+    end
+
+    context 'wrap' do
+      let(:repository) { subject.repository }
+
+      it 'wraps the repository' do
+        expect(RepositoryCompound.wrap(repository)).to eq(subject)
+      end
+    end
+
+    context 'git_directory' do
+      it 'is a Pathname' do
+        expect(RepositoryCompound.git_directory).to be_a(Pathname)
+      end
+    end
+
+    context 'new' do
+      let(:owner) { create(:user) }
+      let(:attributes) { attributes_for(:repository).merge(owner_id: owner.id) }
+
+      it 'builds a RepositoryCompound' do
+        expect(RepositoryCompound.new(attributes)).to be_a(RepositoryCompound)
+      end
+
+      it 'builds a Repository' do
+        expect(RepositoryCompound.new(attributes).repository).
+          to be_a(Repository)
+      end
+
+      it 'sets the repository attributes' do
+        expect(RepositoryCompound.new(attributes).repository.values).
+          to include(attributes)
+      end
+    end
+  end
+
+  context 'save' do
+    let(:owner) { create(:user) }
+    let(:attributes) { attributes_for(:repository).merge(owner_id: owner.id) }
+    subject { RepositoryCompound.new(attributes) }
+    before { subject.save }
+
+    it 'creates a Repository' do
+      expect(Repository.first!(id: subject.id)).to eq(subject.repository)
+    end
+
+    it 'creates a git repository' do
+      expect(subject.git.repo_exists?).to be(true)
+    end
+
+    context 'on an existing object' do
+      before do
+        allow(subject.repository).to receive(:save).and_call_original
+      end
+
+      it 'does not raise an error' do
+        expect { subject.save }.not_to raise_error
+      end
+
+      it 'saves the inner repository' do
+        subject.save
+        expect(subject.repository).to have_received(:save)
+      end
+    end
+  end
+
+  context 'destroy' do
+    subject { create(:repository_compound) }
+    let!(:id) { subject.repository.id }
+    let!(:git) { subject.git }
+    before { subject.destroy }
+
+    it 'deletes the Repository' do
+      expect(Repository.first(id: id)).to be(nil)
+    end
+
+    it 'removes the git repository' do
+      expect(git.repo_exists?).to be(false)
+    end
+  end
+
+  context '==' do
+    it 'detects equality' do
+      expect(subject).to eq(RepositoryCompound.first!(id: subject.id))
+    end
+
+    it 'detects inequality' do
+      expect(subject).not_to eq(create(:repository_compound))
+    end
+  end
+end


### PR DESCRIPTION
This is not yet ready for review. There is one issue I cannot solve and I need help:

The [specs of the ImportingDocumentsReanalyzer](https://github.com/ontohub/ontohub-backend/blob/796a9f6b212b99a8e5c05ca8af763e1b37f52570/spec/lib/importing_documents_reanalyzer_spec.rb#L148-L205) are failing randomly. Even if only one of them is run. Sometimes, it's green and sometimes, it's red.

Apart from this problem:

This finalises the evaluation pipeline. Most of the lines of code are fixtures from Hets-lib. These casl files don't need to be reviewed. Most important, this adds post-processing to analysis jobs:

* A file is saved in a repository
* The backend pushes a job to the HetsAgent
* The HetsAgent runs the job and pushes a job back to the backend (https://github.com/ontohub/hets-agent/pull/38)
* The Backend finds the Documents that import the just analysed Document and invokes the analysis of these (this PR)


This PR depends on https://github.com/ontohub/gitlab_git/pull/20 and https://github.com/ontohub/hets-agent/pull/38