### PR TITLE
Bump FactoryGirl from 4.8.0 to FactoryBot 4.8.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'rack-cors'
 # * `app/graphql/mutations/unlock_account_mutation.rb`
 # when the models bring in a new version of Devise
 gem 'ontohub-models', github: 'ontohub/ontohub-models',
-                      branch: 'master'
+                      branch: 'upgrade_factory_bot'
 
 gem 'gitlab_git', github: 'ontohub/gitlab_git',
                   branch: 'master'
@@ -75,7 +75,7 @@ group :test do
   gem 'bunny-mock', '~> 1.7.0'
   gem 'codecov', '~> 0.1.10', require: false
   gem 'database_cleaner', '~> 1.6.1'
-  gem 'factory_girl_rails', '~> 4.8.0'
+  gem 'factory_bot_rails', '~> 4.8.2'
   gem 'faker', '~> 1.8.4'
   # As soon as a version > 2.8.0 of json-schema is released, use it instead of
   # master.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 9cafea6f5cf5d91a6b858196abed5e844874a98d
-  branch: master
+  revision: 717f0feba95b65d77686c9ccb4d05ee22a030495
+  branch: upgrade_factory_bot
   specs:
     ontohub-models (0.1.0)
       awesome_print (~> 1.8.0)
@@ -160,10 +160,10 @@ GEM
     escape_utils (1.1.1)
     eventmachine (1.0.9.1)
     facter (2.5.1)
-    factory_girl (4.8.1)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
@@ -394,7 +394,7 @@ DEPENDENCIES
   codecov (~> 0.1.10)
   config (~> 1.5.0)
   database_cleaner (~> 1.6.1)
-  factory_girl_rails (~> 4.8.0)
+  factory_bot_rails (~> 4.8.2)
   faker (~> 1.8.4)
   filelock (~> 1.1.1)
   gitlab_git!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'faker'
 require 'ontohub-models/factories'
 

--- a/db/seeds/040_file_seeds.rb
+++ b/db/seeds/040_file_seeds.rb
@@ -7,7 +7,7 @@ repository = RepositoryCompound.wrap(Repository.find(slug: 'ada/fixtures'))
   file = Base64.encode64(File.read(Rails.root.
     join("db/seeds/fixtures/ontohub.#{file_type}")))
 
-  FactoryGirl.create(:additional_file,
+  FactoryBot.create(:additional_file,
                      repository: repository,
                      user: repository.owner,
                      path: "icons/ontohub.#{file_type}",
@@ -19,7 +19,7 @@ end
 text = File.read(Rails.root.join('db/seeds/fixtures/ontohub.txt'))
 path = 'texts/ontohub.txt'
 
-FactoryGirl.create(:additional_file,
+FactoryBot.create(:additional_file,
                    repository: repository,
                    user: repository.owner,
                    path: path,
@@ -30,7 +30,7 @@ FactoryGirl.create(:additional_file,
 new_content = File.read(Rails.root.
   join('db/seeds/fixtures/ontohub_new_content.txt'))
 
-FactoryGirl.create(:additional_commit,
+FactoryBot.create(:additional_commit,
                     repository: repository,
                     user: repository.owner,
                     files: [{path: path,
@@ -42,7 +42,7 @@ FactoryGirl.create(:additional_commit,
 pdf = Base64.encode64(File.read(Rails.root.
   join('db/seeds/fixtures/ontohub.pdf')))
 
-FactoryGirl.create(:additional_file,
+FactoryBot.create(:additional_file,
                    repository: repository,
                    user: repository.owner,
                    path: 'pdf/ontohub.pdf',
@@ -74,7 +74,7 @@ to_be_created_content = File.read(Rails.root.
   join('db/seeds/fixtures/ontohub_to_be_created.txt'))
 to_be_created_path = 'texts/ontohub_created.txt'
 
-FactoryGirl.create(:additional_commit,
+FactoryBot.create(:additional_commit,
                     repository: repository,
                     user: repository.owner,
                     files: [{path: to_be_changed_path,
@@ -94,7 +94,7 @@ FactoryGirl.create(:additional_commit,
                              encoding: 'plain',
                              action: 'create'}])
 
-FactoryGirl.create(:additional_commit,
+FactoryBot.create(:additional_commit,
                     repository: repository,
                     user: repository.owner,
                     files: [{path: to_be_changed_path,

--- a/spec/factories/git_factory.rb
+++ b/spec/factories/git_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:git_user) do |n|
     {email: "git-user-#{n}@example.com",
      name: "git-user#-#{n}",

--- a/spec/factories/repository_compound_factory.rb
+++ b/spec/factories/repository_compound_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :repository_compound do
     transient do
       owner { create(:user) }

--- a/spec/factories/settings_factory.rb
+++ b/spec/factories/settings_factory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :settings, class: OpenStruct do
     skip_create
     initialize_with { OpenStruct.new }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require File.expand_path('../../config/environment', __FILE__)
 if Rails.env.production?
   abort('The Rails environment is running in production mode!')
 end
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'json-schema'
 require 'spec_helper'
 require 'rspec/rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require_relative 'support/simplecov'
 
 require 'rspec'
 require 'database_cleaner'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'ontohub-models/factories'
 
 RSpec.configure do |config|
@@ -60,5 +60,5 @@ RSpec.configure do |config|
   config.order = :random
 
   # Allow to find all factories
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/controller_login_helpers.rb
+++ b/spec/support/controller_login_helpers.rb
@@ -6,7 +6,7 @@ module ControllerLoginHelpers
     def create_user_and_sign_in
       before(:each) do
         @request.env['devise.mapping'] = Devise.mappings[:user]
-        user = FactoryGirl.create(:user)
+        user = FactoryBot.create(:user)
         # Confirm the user. Alternatively, set a confirmed_at inside the
         # factory. Only necessary if you are using the "confirmable" module:
         # user.confirm!
@@ -17,7 +17,7 @@ module ControllerLoginHelpers
 
   module InstanceHelpers
     def create_user_and_set_token_header
-      user = FactoryGirl.create(:user)
+      user = FactoryBot.create(:user)
       set_token_header(user)
       user
     end


### PR DESCRIPTION
FactoryGirl was [renamed to FactoryBot](https://github.com/iHiD/factory_bot/blob/00a5277cb48feaf4c92653442c646442a117c9bd/NAME.md). This migrates the changes.