### PR TITLE
277 dont leak existence of a private repository

### DIFF
--- a/app/graphql/instrumenters/not_found_unless_instrumenter.rb
+++ b/app/graphql/instrumenters/not_found_unless_instrumenter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Instrumenters
+  # Rescues Sequel::ValidationFailed errors and raises
+  # GraphQL::ExecutionError instead
+  class NotFoundUnlessInstrumenter
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    def instrument(_type, field)
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
+      query = field.metadata[:not_found_unless]
+      return field unless query
+
+      old_resolve = field.resolve_proc
+      field.redefine do
+        resolve(lambda do |root, arguments, context|
+          if Pundit.policy!(context[:current_user], root).public_send(query.to_s + '?')
+            return old_resolve.call(root, arguments, context) 
+          end
+
+          context.add_error(GraphQL::ExecutionError.new('resource not found'))
+          nil
+        end)
+      end
+    end
+  end
+end
+
+GraphQL::Field.accepts_definitions(
+  not_found_unless: 
+    GraphQL::Define::InstanceDefinable::AssignMetadataKey.new(:not_found_unless)
+)

--- a/app/graphql/instrumenters/not_found_unless_instrumenter.rb
+++ b/app/graphql/instrumenters/not_found_unless_instrumenter.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
 module Instrumenters
-  # Rescues Sequel::ValidationFailed errors and raises
-  # GraphQL::ExecutionError instead
+  # Instrumenter that allows returning 'resource not found' based on policies
   class NotFoundUnlessInstrumenter
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def instrument(_type, field)
       # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
       query = field.metadata[:not_found_unless]
       return field unless query
 
       old_resolve = field.resolve_proc
       field.redefine do
         resolve(lambda do |root, arguments, context|
-          if Pundit.policy!(context[:current_user], root).public_send(query.to_s + '?')
-            return old_resolve.call(root, arguments, context) 
+          policy = Pundit.policy!(context[:current_user], root)
+          if policy.public_send(query.to_s + '?')
+            return old_resolve.call(root, arguments, context)
           end
 
           context.add_error(GraphQL::ExecutionError.new('resource not found'))
@@ -28,6 +26,6 @@ module Instrumenters
 end
 
 GraphQL::Field.accepts_definitions(
-  not_found_unless: 
+  not_found_unless:
     GraphQL::Define::InstanceDefinable::AssignMetadataKey.new(:not_found_unless)
 )

--- a/app/graphql/mutations/account/add_public_key_mutation.rb
+++ b/app/graphql/mutations/account/add_public_key_mutation.rb
@@ -10,7 +10,8 @@ module Mutations
         description 'The public key to add'
       end
 
-      resource ->(_root, _arguments, context) { context[:current_user] }
+      resource ->(_root, _arguments, context) { context[:current_user] },
+               pass_through: true
 
       authorize!(lambda do |user, _arguments, context|
         UserPolicy.new(user, context[:current_user]).access_private_data?

--- a/app/graphql/mutations/account/delete_account_mutation.rb
+++ b/app/graphql/mutations/account/delete_account_mutation.rb
@@ -13,7 +13,8 @@ module Mutations
         description 'Password of the current user to confirm the deletion'
       end
 
-      resource ->(_root, _arguments, context) { context[:current_user] }
+      resource ->(_root, _arguments, context) { context[:current_user] },
+               pass_through: true
 
       authorize! :destroy, policy: :account
 

--- a/app/graphql/mutations/account/remove_public_key_mutation.rb
+++ b/app/graphql/mutations/account/remove_public_key_mutation.rb
@@ -10,7 +10,8 @@ module Mutations
         description 'The name of the public key to remove'
       end
 
-      resource ->(_root, _arguments, context) { context[:current_user] }
+      resource ->(_root, _arguments, context) { context[:current_user] },
+               pass_through: true
 
       authorize!(lambda do |user, _arguments, context|
         UserPolicy.new(user, context[:current_user]).access_private_data?

--- a/app/graphql/mutations/account/save_account_mutation.rb
+++ b/app/graphql/mutations/account/save_account_mutation.rb
@@ -14,7 +14,8 @@ module Mutations
         description 'Password of the current user to confirm the update'
       end
 
-      resource ->(_root, _arguments, context) { context[:current_user] }
+      resource ->(_root, _arguments, context) { context[:current_user] },
+               pass_through: true
 
       authorize! :update, policy: :account
 

--- a/app/graphql/mutations/repository/add_repository_member_mutation.rb
+++ b/app/graphql/mutations/repository/add_repository_member_mutation.rb
@@ -20,9 +20,11 @@ module Mutations
         description 'The role in the repository'
       end
 
-      resource(lambda do |_root, arguments, _context|
-        ::Repository.first(slug: arguments['repository'])
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.first(slug: arguments['repository'])
       end)
+
+      not_found_unless :show
 
       authorize! :update, policy: :repository
 

--- a/app/graphql/mutations/repository/add_url_mapping_mutation.rb
+++ b/app/graphql/mutations/repository/add_url_mapping_mutation.rb
@@ -16,11 +16,11 @@ module Mutations
         description 'The replacement string of the URL'
       end
 
-      resource!(lambda do |_root, arguments, context|
-        repo = RepositoryCompound.first(slug: arguments[:repositoryId])
-        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
-        repo if may_read
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.first(slug: arguments[:repositoryId])
       end)
+
+      not_found_unless :show
 
       authorize! :update
 

--- a/app/graphql/mutations/repository/add_url_mapping_mutation.rb
+++ b/app/graphql/mutations/repository/add_url_mapping_mutation.rb
@@ -16,8 +16,10 @@ module Mutations
         description 'The replacement string of the URL'
       end
 
-      resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.find(slug: arguments[:repositoryId])
+      resource!(lambda do |_root, arguments, context|
+        repo = RepositoryCompound.first(slug: arguments[:repositoryId])
+        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
+        repo if may_read
       end)
 
       authorize! :update

--- a/app/graphql/mutations/repository/delete_repository_mutation.rb
+++ b/app/graphql/mutations/repository/delete_repository_mutation.rb
@@ -10,8 +10,10 @@ module Mutations
         description 'The ID of the repository to delete'
       end
 
-      resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.find(slug: arguments[:slug])
+      resource!(lambda do |_root, arguments, context|
+        repo = RepositoryCompound.find(slug: arguments[:slug])
+        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
+        repo if may_read
       end)
 
       authorize! :destroy

--- a/app/graphql/mutations/repository/delete_repository_mutation.rb
+++ b/app/graphql/mutations/repository/delete_repository_mutation.rb
@@ -10,11 +10,11 @@ module Mutations
         description 'The ID of the repository to delete'
       end
 
-      resource!(lambda do |_root, arguments, context|
-        repo = RepositoryCompound.find(slug: arguments[:slug])
-        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
-        repo if may_read
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.find(slug: arguments[:slug])
       end)
+
+      not_found_unless :show
 
       authorize! :destroy
 

--- a/app/graphql/mutations/repository/git/commit_mutation.rb
+++ b/app/graphql/mutations/repository/git/commit_mutation.rb
@@ -19,6 +19,8 @@ module Mutations
           RepositoryCompound.find(slug: arguments['repositoryId'])
         end)
 
+        not_found_unless :show
+
         authorize! :write, policy: :repository
 
         resolve CreateCommitResolver.new

--- a/app/graphql/mutations/repository/git/create_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/create_branch_mutation.rb
@@ -23,6 +23,8 @@ module Mutations
           RepositoryCompound.find(slug: arguments['repositoryId'])
         end)
 
+        not_found_unless :show
+
         authorize! :write, policy: :repository
 
         resolve CreateBranchResolver.new

--- a/app/graphql/mutations/repository/git/create_tag_mutation.rb
+++ b/app/graphql/mutations/repository/git/create_tag_mutation.rb
@@ -29,6 +29,8 @@ module Mutations
 
         authorize! :write, policy: :repository
 
+        not_found_unless :show
+
         resolve CreateTagResolver.new
       end
 

--- a/app/graphql/mutations/repository/git/delete_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/delete_branch_mutation.rb
@@ -19,6 +19,8 @@ module Mutations
           RepositoryCompound.find(slug: arguments['repositoryId'])
         end)
 
+        not_found_unless :show
+
         authorize! :write, policy: :repository
 
         resolve DeleteBranchResolver.new

--- a/app/graphql/mutations/repository/git/delete_tag_mutation.rb
+++ b/app/graphql/mutations/repository/git/delete_tag_mutation.rb
@@ -19,6 +19,8 @@ module Mutations
           RepositoryCompound.find(slug: arguments['repositoryId'])
         end)
 
+        not_found_unless :show
+
         authorize! :write, policy: :repository
 
         resolve DeleteTagResolver.new

--- a/app/graphql/mutations/repository/git/set_default_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/set_default_branch_mutation.rb
@@ -19,6 +19,8 @@ module Mutations
           RepositoryCompound.find(slug: arguments['repositoryId'])
         end)
 
+        not_found_unless :show
+
         authorize! :write, policy: :repository
 
         resolve SetDefaultBranchResolver.new

--- a/app/graphql/mutations/repository/remove_repository_member_mutation.rb
+++ b/app/graphql/mutations/repository/remove_repository_member_mutation.rb
@@ -14,9 +14,11 @@ module Mutations
         description 'The ID of the member'
       end
 
-      resource(lambda do |_root, arguments, _context|
-        ::Repository.first(slug: arguments['repository'])
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.first(slug: arguments['repository'])
       end)
+
+      not_found_unless :show
 
       authorize! :update, policy: :repository
 

--- a/app/graphql/mutations/repository/remove_url_mapping_mutation.rb
+++ b/app/graphql/mutations/repository/remove_url_mapping_mutation.rb
@@ -14,8 +14,10 @@ module Mutations
         description 'The ID of the URL mapping'
       end
 
-      resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.first(slug: arguments[:repositoryId])
+      resource!(lambda do |_root, arguments, context|
+        repo = RepositoryCompound.first(slug: arguments[:repositoryId])
+        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
+        repo if may_read
       end)
 
       authorize! :update

--- a/app/graphql/mutations/repository/remove_url_mapping_mutation.rb
+++ b/app/graphql/mutations/repository/remove_url_mapping_mutation.rb
@@ -14,11 +14,11 @@ module Mutations
         description 'The ID of the URL mapping'
       end
 
-      resource!(lambda do |_root, arguments, context|
-        repo = RepositoryCompound.first(slug: arguments[:repositoryId])
-        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
-        repo if may_read
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.first(slug: arguments[:repositoryId])
       end)
+
+      not_found_unless :show
 
       authorize! :update
 

--- a/app/graphql/mutations/repository/save_repository_mutation.rb
+++ b/app/graphql/mutations/repository/save_repository_mutation.rb
@@ -14,11 +14,11 @@ module Mutations
         description 'Updated fields of the repository'
       end
 
-      resource!(lambda do |_root, arguments, context|
-        repo = RepositoryCompound.find(slug: arguments[:slug])
-        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
-        repo if may_read
+      resource!(lambda do |_root, arguments, _context|
+        RepositoryCompound.find(slug: arguments[:slug])
       end)
+
+      not_found_unless :show
 
       authorize! :update
 

--- a/app/graphql/mutations/repository/save_repository_mutation.rb
+++ b/app/graphql/mutations/repository/save_repository_mutation.rb
@@ -14,8 +14,10 @@ module Mutations
         description 'Updated fields of the repository'
       end
 
-      resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.find(slug: arguments[:slug])
+      resource!(lambda do |_root, arguments, context|
+        repo = RepositoryCompound.find(slug: arguments[:slug])
+        may_read = RepositoryPolicy.new(context[:current_user], repo).show?
+        repo if may_read
       end)
 
       authorize! :update

--- a/app/graphql/ontohub_backend_schema.rb
+++ b/app/graphql/ontohub_backend_schema.rb
@@ -13,6 +13,7 @@ OntohubBackendSchema = GraphQL::Schema.define do
   # correct order
   instrument(:field, Instrumenters::ValidationErrorInstrumenter.new)
   instrument(:field, GraphQL::Pundit::Instrumenter.new)
+  instrument(:field, Instrumenters::NotFoundUnlessInstrumenter.new)
   instrument(:field, Instrumenters::ResourceInstrumenter.new)
   query(Types::QueryType)
   mutation(Types::MutationType)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,7 +33,7 @@ Types::QueryType = GraphQL::ObjectType.define do
 
     authorize :show
 
-    resource!(lambda do |_root, arguments, _context|
+    resource(lambda do |_root, arguments, _context|
       RepositoryCompound.find(slug: arguments[:slug])
     end)
 

--- a/app/policies/repository_policy.rb
+++ b/app/policies/repository_policy.rb
@@ -22,6 +22,7 @@ class RepositoryPolicy < ApplicationPolicy
   end
 
   def show?
+    return false unless resource
     resource.public_access ||
       !!current_user&.accessible_repositories_dataset&.
         where(slug: resource.to_param)&.any?

--- a/spec/graphql/mutations/git/commit_mutation_spec.rb
+++ b/spec/graphql/mutations/git/commit_mutation_spec.rb
@@ -259,6 +259,20 @@ RSpec.describe 'commit mutation' do
       end
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['commit']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 

--- a/spec/graphql/mutations/git/create_branch_mutation_spec.rb
+++ b/spec/graphql/mutations/git/create_branch_mutation_spec.rb
@@ -67,11 +67,25 @@ RSpec.describe 'createBranch mutation' do
         to include(include('message' => include('already exists')))
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private, :not_empty) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['createBranch']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 
       it 'returns no data' do
-        expect(subject['data']['commit']).to be(nil)
+        expect(subject['data']['createBranch']).to be(nil)
       end
 
       it 'returns an error' do

--- a/spec/graphql/mutations/git/create_tag_mutation_spec.rb
+++ b/spec/graphql/mutations/git/create_tag_mutation_spec.rb
@@ -91,11 +91,25 @@ RSpec.describe 'createTag mutation' do
         to include(include('message' => include('already exists')))
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private, :not_empty) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['createTag']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 
       it 'returns no data' do
-        expect(subject['data']['commit']).to be(nil)
+        expect(subject['data']['createTag']).to be(nil)
       end
 
       it 'returns an error' do

--- a/spec/graphql/mutations/git/delete_branch_mutation_spec.rb
+++ b/spec/graphql/mutations/git/delete_branch_mutation_spec.rb
@@ -64,11 +64,25 @@ RSpec.describe 'deleteBranch mutation' do
       expect(repository.git.branch_names).to include(name)
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private, :not_empty) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['deleteBranch']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 
       it 'returns no data' do
-        expect(subject['data']['commit']).to be(nil)
+        expect(subject['data']['deleteBranch']).to be(nil)
       end
 
       it 'returns an error' do

--- a/spec/graphql/mutations/git/delete_tag_mutation_spec.rb
+++ b/spec/graphql/mutations/git/delete_tag_mutation_spec.rb
@@ -64,11 +64,25 @@ RSpec.describe 'deleteTag mutation' do
       expect(repository.git.tag_names).to include(name)
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private, :not_empty) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['deleteTag']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 
       it 'returns no data' do
-        expect(subject['data']['commit']).to be(nil)
+        expect(subject['data']['deleteTag']).to be(nil)
       end
 
       it 'returns an error' do

--- a/spec/graphql/mutations/git/set_default_branch_mutation_spec.rb
+++ b/spec/graphql/mutations/git/set_default_branch_mutation_spec.rb
@@ -72,11 +72,25 @@ RSpec.describe 'createBranch mutation' do
                              %(The branch "#{name_argument}" does not exist.)))
     end
 
+    context 'because the repository is private' do
+      let!(:repository) { create(:repository_compound, :private, :not_empty) }
+      let(:context) { {} }
+
+      it 'returns no data' do
+        expect(subject['data']['setDefaultBranch']).to be(nil)
+      end
+
+      it 'returns an error' do
+        expect(subject['errors']).
+          to include(include('message' => 'resource not found'))
+      end
+    end
+
     context 'because the user is not signed in' do
       let(:context) { {} }
 
       it 'returns no data' do
-        expect(subject['data']['commit']).to be(nil)
+        expect(subject['data']['setDefaultBranch']).to be(nil)
       end
 
       it 'returns an error' do

--- a/spec/graphql/mutations/repository/add_repository_member_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/add_repository_member_mutation_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Mutations::Repository::AddRepositoryMemberMutation do
     end
   end
 
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+    let(:role) { 'read' }
+
+    it 'returns an error' do
+      expect(subject['data']['addRepositoryMember']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
+    end
+  end
+
   context 'Not signed in' do
     let(:context) { {} }
     let(:role) { 'read' }

--- a/spec/graphql/mutations/repository/add_url_mapping_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/add_url_mapping_mutation_spec.rb
@@ -55,6 +55,17 @@ RSpec.describe Mutations::Repository::AddUrlMappingMutation do
     end
   end
 
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+
+    it 'returns an error' do
+      expect(subject['data']['addUrlMapping']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
+    end
+  end
+
   context 'User not signed in' do
     let(:current_user) { nil }
     it 'returns an error' do

--- a/spec/graphql/mutations/repository/delete_repository_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/delete_repository_mutation_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe 'deleteRepository mutation' do
     end
   end
 
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+
+    it 'returns an error' do
+      expect(subject['data']['deleteRepository']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
+    end
+  end
+
   context 'Not signed in' do
     let(:context) { {} }
 

--- a/spec/graphql/mutations/repository/remove_repository_member_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/remove_repository_member_mutation_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Mutations::Repository::RemoveRepositoryMemberMutation do
     end
   end
 
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+
+    it 'returns an error' do
+      expect(subject['data']['removeRepositoryMember']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
+    end
+  end
+
   context 'Not signed in' do
     let(:context) { {} }
 

--- a/spec/graphql/mutations/repository/remove_url_mapping_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/remove_url_mapping_mutation_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Repository::RemoveUrlMappingMutation do
   let!(:user) { create :user }
-  let(:url_mapping) { create(:url_mapping) }
-  let(:repository) { url_mapping.repository }
+  let(:repository) { create(:repository_compound) }
+  let(:url_mapping) { create(:url_mapping, repository_id: repository.id) }
   before do
     repository.add_member(user, 'admin')
   end
@@ -92,6 +92,17 @@ RSpec.describe Mutations::Repository::RemoveUrlMappingMutation do
           let(:error_message) { 'resource not found' }
         end
       end
+    end
+  end
+
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+
+    it 'returns an error' do
+      expect(subject['data']['removeMapping']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
     end
   end
 

--- a/spec/graphql/mutations/repository/remove_url_mapping_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/remove_url_mapping_mutation_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Mutations::Repository::RemoveUrlMappingMutation do
     let(:context) { {} }
 
     it 'returns an error' do
-      expect(subject['data']['removeMapping']).to be(nil)
+      expect(subject['data']['removeUrlMapping']).to be(nil)
       expect(subject['errors']).
         to include(include('message' => 'resource not found'))
     end

--- a/spec/graphql/mutations/repository/save_repository_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/save_repository_mutation_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe 'saveRepository mutation' do
     end
   end
 
+  context 'Unable to see the repository' do
+    let!(:repository) { create :repository_compound, :private }
+    let(:context) { {} }
+
+    it 'returns an error' do
+      expect(subject['data']['saveRepository']).to be(nil)
+      expect(subject['errors']).
+        to include(include('message' => 'resource not found'))
+    end
+  end
+
   context 'Not signed in' do
     let(:context) { {} }
 

--- a/spec/graphql/queries/repository_query_spec.rb
+++ b/spec/graphql/queries/repository_query_spec.rb
@@ -74,5 +74,26 @@ RSpec.describe 'Repository query' do
       repository = result['data']['repository']
       expect(repository).to be_nil
     end
+
+    it 'does not return an error' do
+      expect(subject['errors'] || {}).
+        not_to include(include('message' => 'resource not found'))
+    end
+  end
+
+  context 'private repository' do
+    let!(:repository) do
+      create(:repository_compound, :not_empty, :private)
+    end
+
+    it 'returns null' do
+      repository = result['data']['repository']
+      expect(repository).to be_nil
+    end
+
+    it 'does not return an error' do
+      expect(result['errors'] || {}).
+        not_to include(include('message' => 'resource not found'))
+    end
   end
 end

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe RepositoryPolicy do
   end
 
   context 'show?' do
+    context 'no repository' do
+      subject { RepositoryPolicy.new(user, nil) }
+
+      it 'returns false' do
+        expect(subject.show?).to be(false)
+      end
+    end
+
     context 'public repository' do
       context 'signed in' do
         subject { RepositoryPolicy.new(user, public_repo) }


### PR DESCRIPTION
Fixes #277. At least in part.

There are at least two other places where we leak the existence of private repositories:

- `DeleteRepositoryMutation`
- `SaveRepositoryMutation`

These both return an error if the repository does not exist, but a different error if the user is unauthorized to perform the mutations. I'm unclear about how to solve this: how do we check if a user is authorized to see if a non-existent repository is not existent? Returning `unauthorized` even if the repo does not exist? Could be confusing if there's just a typo in the name.