### PR TITLE
Act as if not signed in when receiving an invalid JWT

### DIFF
--- a/config/initializers/core_extensions/devise/strategies/json_web_token.rb
+++ b/config/initializers/core_extensions/devise/strategies/json_web_token.rb
@@ -12,7 +12,7 @@ module Devise
       end
 
       def authenticate!
-        throw(:warden) unless claims&.key?('user_id')
+        return unless claims&.key?('user_id')
 
         success! User.find(
           Sequel[:organizational_units][:slug] => claims['user_id']

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -126,10 +126,9 @@ RSpec.describe GraphqlController do
             params: params
         end
 
-        it { expect(response).to have_http_status(:unauthorized) }
-        it 'returns the queried user data' do
-          expect(response.body).
-            to eq('You need to sign in or sign up before continuing.')
+        it { expect(response).to have_http_status(:ok) }
+        it 'returns no user data' do
+          expect(result.dig('data', 'me')).to be(nil)
         end
       end
     end


### PR DESCRIPTION
Returning `unauthorized` is not a good idea for the GraphQL API, so just acting as if no token was sent is the better way.