### PR TITLE
181 Add API keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 0f279f0a7734da0a42c205fe0728dcaade6caef8
+  revision: c8482f769f7a1e0de0111c5b6e1ce2a36ffb8ca4
   branch: master
   specs:
     ontohub-models (0.1.0)
@@ -431,4 +431,4 @@ DEPENDENCIES
   sprockets-rails
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,9 +8,19 @@ class ApplicationPolicy
     @current_user = current_user
     @resource = resource
 
-    return unless @current_user&.admin?
+    if current_user.is_a?(ApiKey)
+      define_methods(false, show?: true)
+    elsif current_user&.admin?
+      define_methods(true)
+    end
+  end
+
+  private
+
+  def define_methods(default_result, **exceptions)
     (self.class.instance_methods - Object.methods).each do |method|
-      define_singleton_method(method, ->(*_args) { true })
+      result = exceptions[method] || default_result
+      define_singleton_method(method, ->(*_args) { result })
     end
   end
 end

--- a/app/policies/repository_policy.rb
+++ b/app/policies/repository_policy.rb
@@ -13,6 +13,7 @@ class RepositoryPolicy < ApplicationPolicy
     end
 
     def resolve
+      return scope if user.is_a?(ApiKey)
       return scope if user&.admin?
       return scope.where(public_access: true) unless user
 

--- a/config/initializers/core_extensions/devise/strategies/api_key.rb
+++ b/config/initializers/core_extensions/devise/strategies/api_key.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'http_authorization.rb'
+
+module Devise
+  module Strategies
+    # Strategy for API key authentication
+    class ApiKey < HttpAuthorization
+      def authenticate!
+        api_key = ::ApiKey.
+          verify(Rails.application.secrets.api_key_base, user_key)
+
+        success! api_key if api_key
+      end
+
+      protected
+
+      def user_key
+        _strategy, token = strategy_and_token
+        token
+      end
+
+      private
+
+      def expected_strategy
+        'apikey'
+      end
+    end
+  end
+end

--- a/config/initializers/core_extensions/devise/strategies/http_authorization.rb
+++ b/config/initializers/core_extensions/devise/strategies/http_authorization.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Devise
+  module Strategies
+    # Strategy for HTTP authentication header
+    class HttpAuthorization < Base
+      def valid?
+        return false if request.headers['HTTP_AUTHORIZATION'].blank?
+
+        strategy, _token = strategy_and_token
+        (strategy || '').casecmp(expected_strategy).zero?
+      end
+
+      # Implement this in the subclasses
+      def authenticate!; end
+
+      protected
+
+      def strategy_and_token
+        @strategy_and_token ||= request.headers['HTTP_AUTHORIZATION'].split(' ')
+      end
+
+      private
+
+      # Implement this in the subclasses
+      def expected_strategy; end
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,12 +281,13 @@ Devise.setup do |config|
   # end
 
   config.warden do |manager|
-    # Registering your new Strategy
+    # Register the custom Strategies
+    manager.strategies.add(:api, Devise::Strategies::ApiKey)
     manager.strategies.add(:jwt, Devise::Strategies::JsonWebToken)
 
-    # Adding the new JWT Strategy to the top of Warden's list,
-    # Scoped by what Devise would scope (typically :user)
-    manager.default_strategies(scope: :user).unshift :jwt
+    # Add the new ApiKey and JWT strategies to the top of Warden's list
+    manager.default_strategies(:jwt, :api, :database_authenticatable,
+                               scope: :user)
   end
 
   # ==> Mountable engine configurations When using Devise inside an engine,

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,7 @@
 
 development:
   secret_key_base: af6e02630acab360f575e7679ab159cfd6a29730d4e9b140093d07c9fd92a792029a37f279b83a969964bcbacf20bf3df3e2e71fda196c6c5e72220a24add2f8
+  api_key_base: 2cd96f28ae00a0ec0bae7599632028c2d3cc223df68d29fd90110d3129218181188c9f4b7a174f888f22ce52a7fd02815ce318f1b9e9711ceead100fd6086ef9
   jwt:
     private: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIAZubo2MugYzGKhQL+NKdeYtJns+pwgaGKFBavWxaFPGoAoGCCqGSM49\nAwEHoUQDQgAEA1w15z6CQvCYypkndy5aIVQpfw5bTahLPleHcS09KL5BlmXtMv6R\nYptBFPxKC0YS1AK9ABlukSxqsKOSNipsZw==\n-----END EC PRIVATE KEY-----\n"
     public: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEA1w15z6CQvCYypkndy5aIVQpfw5b\nTahLPleHcS09KL5BlmXtMv6RYptBFPxKC0YS1AK9ABlukSxqsKOSNipsZw==\n-----END PUBLIC KEY-----\n"
@@ -21,6 +22,7 @@ development:
 
 test:
   secret_key_base: 778e0b407acfd29e591f86147e2c8ab5988343f9fb13705ba02ba4d45dba8e0890353e376abee53dfaaa37fe6dd93e4b4573ea1ec8391d27bf23765d85e7035d
+  api_key_base: 1de825dbe2987cef1a5726486f5ba12acbfb014df471b0e9cfaf9302d3da982ce4378371e2cfcc7a9cf0be9b35402dddc723b269a940d8065748015a7993277b
   jwt:
     private: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIHnY7HpcTzF6RQs1OTOV8K3mxiyV9UzTYP1LZpC01/3qoAoGCCqGSM49\nAwEHoUQDQgAEcrNf6uwCm3frHupIB42tD5PONt1CKzGKs9IWhhITWLYeTv/AuLOn\nqOVSnp0csOhmZjq/LCcFzKWXYeEw/tsr5A==\n-----END EC PRIVATE KEY-----\n"
     public:  "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcrNf6uwCm3frHupIB42tD5PONt1C\nKzGKs9IWhhITWLYeTv/AuLOnqOVSnp0csOhmZjq/LCcFzKWXYeEw/tsr5A==\n-----END PUBLIC KEY-----\n"
@@ -32,6 +34,7 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  api_key_base: <%= ENV["API_KEY_BASE"] %>
   jwt:
     private: <%= ENV["JWT_SECRET_PRIVATE"] %>
     public: <%= ENV["JWT_SECRET_PUBLIC"] %>

--- a/db/seeds/011_api_key_seeds.rb
+++ b/db/seeds/011_api_key_seeds.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+raw_key = 'FqeNBVtaNi3D5Bdsgk6_DDCbMqATpsEYxBtx3iZmsfb7y21rHqEXYnXRb3AasEZY'
+encoded_key = ApiKey.digest(Rails.application.secrets.api_key_base, raw_key)
+ApiKey.create(key: encoded_key, comment: 'seeded key')

--- a/lib/tasks/apikey.rake
+++ b/lib/tasks/apikey.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :apikey do
+  desc "Create a new API key - set the comment with ENV['COMMENT']"
+  task create: :environment do
+    comment = ENV['COMMENT']
+    key = ApiKey.generate(Rails.application.secrets.api_key_base, 80)
+    ApiKey.create(key: key[:encoded], comment: comment)
+
+    comment_out = comment.present? ? " (#{comment})" : ''
+    $stdout.puts "Created API key#{comment_out}:"
+    $stdout.puts "Raw Key:\n#{key[:raw]}"
+  end
+end

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -3,84 +3,99 @@
 require 'rails_helper'
 
 RSpec.describe AccountPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'create?' do
-    context 'not signed in' do
-      subject { AccountPolicy.new(nil) }
+    context 'create?' do
+      context 'not signed in' do
+        subject { AccountPolicy.new(nil) }
 
-      it 'allows to create an account' do
-        expect(subject.create?).to be(true)
+        it 'allows to create an account' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'signed in as user' do
+        subject { AccountPolicy.new(user) }
+
+        it 'does not allow to create an account' do
+          expect(subject.create?).to be(false)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { AccountPolicy.new(admin) }
+
+        it 'allows to create an account '\
+          '(makes no sense, but admin is god)' do
+          expect(subject.create?).to be(true)
+        end
       end
     end
 
-    context 'signed in as user' do
-      subject { AccountPolicy.new(user) }
+    context 'update?' do
+      context 'not signed in' do
+        subject { AccountPolicy.new(nil) }
 
-      it 'does not allow to create an account' do
-        expect(subject.create?).to be(false)
+        it 'does not allow to update the account' do
+          expect(subject.update?).to be(false)
+        end
+      end
+
+      context 'signed in as user' do
+        subject { AccountPolicy.new(user) }
+
+        it 'does not allow to update the account' do
+          expect(subject.update?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { AccountPolicy.new(admin) }
+
+        it 'allows to update the account' do
+          expect(subject.update?).to be(true)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { AccountPolicy.new(admin) }
+    context 'destroy?' do
+      context 'not signed in' do
+        subject { AccountPolicy.new(nil) }
 
-      it 'allows to create an account '\
-        '(makes no sense, but admin is god)' do
-        expect(subject.create?).to be(true)
+        it 'does not allow to destroy the account' do
+          expect(subject.destroy?).to be(false)
+        end
+      end
+
+      context 'signed in as user' do
+        subject { AccountPolicy.new(user) }
+
+        it 'does not allow to destroy the account' do
+          expect(subject.destroy?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { AccountPolicy.new(admin) }
+
+        it 'allows to destroy the account' do
+          expect(subject.destroy?).to be(true)
+        end
       end
     end
   end
 
-  context 'update?' do
-    context 'not signed in' do
-      subject { AccountPolicy.new(nil) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { AccountPolicy.new(current_user) }
 
-      it 'does not allow to update the account' do
-        expect(subject.update?).to be(false)
-      end
-    end
-
-    context 'signed in as user' do
-      subject { AccountPolicy.new(user) }
-
-      it 'does not allow to update the account' do
-        expect(subject.update?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { AccountPolicy.new(admin) }
-
-      it 'allows to update the account' do
-        expect(subject.update?).to be(true)
-      end
-    end
-  end
-
-  context 'destroy?' do
-    context 'not signed in' do
-      subject { AccountPolicy.new(nil) }
-
-      it 'does not allow to destroy the account' do
-        expect(subject.destroy?).to be(false)
-      end
-    end
-
-    context 'signed in as user' do
-      subject { AccountPolicy.new(user) }
-
-      it 'does not allow to destroy the account' do
-        expect(subject.destroy?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { AccountPolicy.new(admin) }
-
-      it 'allows to destroy the account' do
-        expect(subject.destroy?).to be(true)
+    %i(create? update? destroy?).each do |method|
+      context method.to_s do
+        it 'does not allow the action' do
+          expect(subject.public_send(method)).to be(false)
+        end
       end
     end
   end

--- a/spec/policies/confirmation_policy_spec.rb
+++ b/spec/policies/confirmation_policy_spec.rb
@@ -3,57 +3,70 @@
 require 'rails_helper'
 
 RSpec.describe ConfirmationPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'create?' do
-    context 'signed in' do
-      subject { ConfirmationPolicy.new(user) }
+    context 'create?' do
+      context 'signed in' do
+        subject { ConfirmationPolicy.new(user) }
 
-      it 'allows to resend email' do
-        expect(subject.create?).to be(true)
+        it 'allows to resend email' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { ConfirmationPolicy.new(admin) }
+
+        it 'allows to resend email' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { ConfirmationPolicy.new(nil) }
+
+        it 'allows to resend email' do
+          expect(subject.create?).to be(true)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { ConfirmationPolicy.new(admin) }
+    context 'update?' do
+      context 'signed in' do
+        subject { ConfirmationPolicy.new(user) }
 
-      it 'allows to resend email' do
-        expect(subject.create?).to be(true)
+        it 'allows to perform the confirmation' do
+          expect(subject.update?).to be(true)
+        end
       end
-    end
 
-    context 'not signed in' do
-      subject { ConfirmationPolicy.new(nil) }
+      context 'signed in as admin' do
+        subject { ConfirmationPolicy.new(admin) }
 
-      it 'allows to resend email' do
-        expect(subject.create?).to be(true)
+        it 'allows to perform the confirmation' do
+          expect(subject.update?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { ConfirmationPolicy.new(nil) }
+
+        it 'allows to perform the confirmation' do
+          expect(subject.update?).to be(true)
+        end
       end
     end
   end
 
-  context 'update?' do
-    context 'signed in' do
-      subject { ConfirmationPolicy.new(user) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { ConfirmationPolicy.new(current_user) }
 
-      it 'allows to perform the confirmation' do
-        expect(subject.update?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { ConfirmationPolicy.new(admin) }
-
-      it 'allows to perform the confirmation' do
-        expect(subject.update?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { ConfirmationPolicy.new(nil) }
-
-      it 'allows to perform the confirmation' do
-        expect(subject.update?).to be(true)
+    %i(create? update?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
   end

--- a/spec/policies/organization_policy_spec.rb
+++ b/spec/policies/organization_policy_spec.rb
@@ -3,143 +3,160 @@
 require 'rails_helper'
 
 RSpec.describe OrganizationPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
-  let(:organization) { create :organization }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
+    let(:organization) { create :organization }
 
-  context 'create?' do
-    context 'signed in' do
-      subject { OrganizationPolicy.new(user, organization) }
+    context 'create?' do
+      context 'signed in' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'allows to create the organization' do
-        expect(subject.create?).to be(true)
+        it 'allows to create the organization' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { OrganizationPolicy.new(admin, organization) }
+
+        it 'allows to create the organization' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { OrganizationPolicy.new(nil, organization) }
+
+        it 'does not allow to create the organization' do
+          expect(subject.create?).to be(false)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { OrganizationPolicy.new(admin, organization) }
+    context 'show?' do
+      context 'signed in' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'allows to create the organization' do
-        expect(subject.create?).to be(true)
+        it 'allows to show the organization' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { OrganizationPolicy.new(admin, organization) }
+
+        it 'allows to show the organization' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { OrganizationPolicy.new(nil, organization) }
+
+        it 'allows to show the organization' do
+          expect(subject.show?).to be(true)
+        end
       end
     end
 
-    context 'not signed in' do
-      subject { OrganizationPolicy.new(nil, organization) }
+    context 'update?' do
+      context 'by membership' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'does not allow to create the organization' do
-        expect(subject.create?).to be(false)
+        %w(write read).each do |role|
+          it "with role #{role} does not allow to update the organization" do
+            organization.add_member(user, role)
+            expect(subject.update?).to be(false)
+          end
+        end
+
+        it 'with role admin allows to update the organization' do
+          organization.add_member(user, 'admin')
+          expect(subject.update?).to be(true)
+        end
       end
-    end
-  end
 
-  context 'show?' do
-    context 'signed in' do
-      subject { OrganizationPolicy.new(user, organization) }
+      context 'signed in as admin' do
+        subject { OrganizationPolicy.new(admin, organization) }
 
-      it 'allows to show the organization' do
-        expect(subject.show?).to be(true)
+        it 'allows to update the organization' do
+          expect(subject.update?).to be(true)
+        end
       end
-    end
 
-    context 'signed in as admin' do
-      subject { OrganizationPolicy.new(admin, organization) }
+      context 'signed in as user without membership' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'allows to show the organization' do
-        expect(subject.show?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { OrganizationPolicy.new(nil, organization) }
-
-      it 'allows to show the organization' do
-        expect(subject.show?).to be(true)
-      end
-    end
-  end
-
-  context 'update?' do
-    context 'by membership' do
-      subject { OrganizationPolicy.new(user, organization) }
-
-      %w(write read).each do |role|
-        it "with role #{role} does not allow to update the organization" do
-          organization.add_member(user, role)
+        it 'allows to update the organization' do
           expect(subject.update?).to be(false)
         end
       end
 
-      it 'with role admin allows to update the organization' do
-        organization.add_member(user, 'admin')
-        expect(subject.update?).to be(true)
+      context 'not signed in' do
+        subject { OrganizationPolicy.new(nil, organization) }
+
+        it 'does not allow to update the organization' do
+          expect(subject.update?).to be(false)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { OrganizationPolicy.new(admin, organization) }
+    context 'destroy?' do
+      context 'by membership' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'allows to update the organization' do
-        expect(subject.update?).to be(true)
+        %w(write read).each do |role|
+          it "with role #{role} does not allow to destroy the organization" do
+            organization.add_member(user, role)
+            expect(subject.destroy?).to be(false)
+          end
+        end
+
+        it 'with role admin allows to destroy the organization' do
+          organization.add_member(user, 'admin')
+          expect(subject.destroy?).to be(true)
+        end
       end
-    end
 
-    context 'signed in as user without membership' do
-      subject { OrganizationPolicy.new(user, organization) }
+      context 'signed in as admin' do
+        subject { OrganizationPolicy.new(admin, organization) }
 
-      it 'allows to update the organization' do
-        expect(subject.update?).to be(false)
+        it 'allows to destroy the organization' do
+          expect(subject.destroy?).to be(true)
+        end
       end
-    end
 
-    context 'not signed in' do
-      subject { OrganizationPolicy.new(nil, organization) }
+      context 'signed in as user' do
+        subject { OrganizationPolicy.new(user, organization) }
 
-      it 'does not allow to update the organization' do
-        expect(subject.update?).to be(false)
-      end
-    end
-  end
-
-  context 'destroy?' do
-    context 'by membership' do
-      subject { OrganizationPolicy.new(user, organization) }
-
-      %w(write read).each do |role|
-        it "with role #{role} does not allow to destroy the organization" do
-          organization.add_member(user, role)
+        it 'does not allow to destroy the organization' do
           expect(subject.destroy?).to be(false)
         end
       end
 
-      it 'with role admin allows to destroy the organization' do
-        organization.add_member(user, 'admin')
-        expect(subject.destroy?).to be(true)
+      context 'not signed in' do
+        subject { OrganizationPolicy.new(nil, organization) }
+
+        it 'does not allow to destroy the organization' do
+          expect(subject.destroy?).to be(false)
+        end
+      end
+    end
+  end
+
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { OrganizationPolicy.new(current_user) }
+
+    %i(create? update? destroy?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
 
-    context 'signed in as admin' do
-      subject { OrganizationPolicy.new(admin, organization) }
-
-      it 'allows to destroy the organization' do
-        expect(subject.destroy?).to be(true)
-      end
-    end
-
-    context 'signed in as user' do
-      subject { OrganizationPolicy.new(user, organization) }
-
-      it 'does not allow to destroy the organization' do
-        expect(subject.destroy?).to be(false)
-      end
-    end
-
-    context 'not signed in' do
-      subject { OrganizationPolicy.new(nil, organization) }
-
-      it 'does not allow to destroy the organization' do
-        expect(subject.destroy?).to be(false)
-      end
+    it 'does allow show?' do
+      expect(subject.show?).to be(true)
     end
   end
 end

--- a/spec/policies/organizational_unit_policy_spec.rb
+++ b/spec/policies/organizational_unit_policy_spec.rb
@@ -3,32 +3,43 @@
 require 'rails_helper'
 
 RSpec.describe OrganizationalUnitPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'show?' do
-    context 'signed in' do
-      subject { OrganizationalUnitPolicy.new(user) }
+    context 'show?' do
+      context 'signed in' do
+        subject { OrganizationalUnitPolicy.new(user) }
 
-      it 'allows to show the organizational unit' do
-        expect(subject.show?).to be(true)
+        it 'allows to show the organizational unit' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { OrganizationalUnitPolicy.new(admin) }
+
+        it 'allows to show the organizational unit' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { OrganizationalUnitPolicy.new(nil) }
+
+        it 'allows to show the organizational unit' do
+          expect(subject.show?).to be(true)
+        end
       end
     end
+  end
 
-    context 'signed in as admin' do
-      subject { OrganizationalUnitPolicy.new(admin) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { OrganizationalUnitPolicy.new(current_user) }
 
-      it 'allows to show the organizational unit' do
-        expect(subject.show?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { OrganizationalUnitPolicy.new(nil) }
-
-      it 'allows to show the organizational unit' do
-        expect(subject.show?).to be(true)
-      end
+    it 'does allow show?' do
+      expect(subject.show?).to be(true)
     end
   end
 end

--- a/spec/policies/password_policy_spec.rb
+++ b/spec/policies/password_policy_spec.rb
@@ -3,57 +3,70 @@
 require 'rails_helper'
 
 RSpec.describe PasswordPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'recover_password?' do
-    context 'signed in' do
-      subject { PasswordPolicy.new(user) }
+    context 'recover_password?' do
+      context 'signed in' do
+        subject { PasswordPolicy.new(user) }
 
-      it 'allows to recover the password' do
-        expect(subject.recover_password?).to be(true)
+        it 'allows to recover the password' do
+          expect(subject.recover_password?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { PasswordPolicy.new(admin) }
+
+        it 'allows to recover the password' do
+          expect(subject.recover_password?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { PasswordPolicy.new(nil) }
+
+        it 'allows to recover the password' do
+          expect(subject.recover_password?).to be(true)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { PasswordPolicy.new(admin) }
+    context 'resend_password_recovery_email?' do
+      context 'signed in' do
+        subject { PasswordPolicy.new(user) }
 
-      it 'allows to recover the password' do
-        expect(subject.recover_password?).to be(true)
+        it 'allows to resend the password recovery email' do
+          expect(subject.resend_password_recovery_email?).to be(true)
+        end
       end
-    end
 
-    context 'not signed in' do
-      subject { PasswordPolicy.new(nil) }
+      context 'signed in as admin' do
+        subject { PasswordPolicy.new(admin) }
 
-      it 'allows to recover the password' do
-        expect(subject.recover_password?).to be(true)
+        it 'allows to resend the password recovery email' do
+          expect(subject.resend_password_recovery_email?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { PasswordPolicy.new(nil) }
+
+        it 'allows to resend the password recovery email' do
+          expect(subject.resend_password_recovery_email?).to be(true)
+        end
       end
     end
   end
 
-  context 'resend_password_recovery_email?' do
-    context 'signed in' do
-      subject { PasswordPolicy.new(user) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { PasswordPolicy.new(current_user) }
 
-      it 'allows to resend the password recovery email' do
-        expect(subject.resend_password_recovery_email?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { PasswordPolicy.new(admin) }
-
-      it 'allows to resend the password recovery email' do
-        expect(subject.resend_password_recovery_email?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { PasswordPolicy.new(nil) }
-
-      it 'allows to resend the password recovery email' do
-        expect(subject.resend_password_recovery_email?).to be(true)
+    %i(recover_password? resend_password_recovery_email?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
   end

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -3,416 +3,504 @@
 require 'rails_helper'
 
 RSpec.describe RepositoryPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
-  let(:public_repo) { create :repository, public_access: true }
-  let(:private_repo) { create :repository, public_access: false }
-  let(:organization) { create :organization }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
+    let(:public_repo) { create :repository, public_access: true }
+    let(:private_repo) { create :repository, public_access: false }
+    let(:organization) { create :organization }
 
-  describe RepositoryPolicy::Scope do
-    subject { RepositoryPolicy::Scope.new(current_user, scope) }
-    let(:scope) { Repository.dataset }
+    describe RepositoryPolicy::Scope do
+      subject { RepositoryPolicy::Scope.new(current_user, scope) }
+      let(:scope) { Repository.dataset }
 
-    before do
-      2.times do
-        create :repository
-      end
-      3.times do
-        create :repository, public_access: true
-      end
-      2.times do
-        repo = create :repository
-        repo.add_member(user, :read)
-      end
-    end
-
-    context 'signed in as admin' do
-      let(:current_user) { admin }
-
-      it 'returns all repositories' do
-        expect(subject.resolve.to_a.size).to eq(7)
-      end
-    end
-
-    context 'signed in as normal user' do
-      let(:current_user) { user }
-
-      it 'returns public repositories and ones with explicit access' do
-        expect(subject.resolve.to_a.size).to eq(5)
-      end
-    end
-
-    context 'not signed in' do
-      let(:current_user) { nil }
-
-      it 'returns only public repositories' do
-        expect(subject.resolve.to_a.size).to eq(3)
-      end
-    end
-  end
-
-  context 'show?' do
-    context 'no repository' do
-      subject { RepositoryPolicy.new(user, nil) }
-
-      it 'returns false' do
-        expect(subject.show?).to be(false)
-      end
-    end
-
-    context 'public repository' do
-      context 'signed in' do
-        subject { RepositoryPolicy.new(user, public_repo) }
-
-        it 'allows to show the repository' do
-          expect(subject.show?).to be(true)
+      before do
+        2.times do
+          create(:repository, public_access: false)
+        end
+        3.times do
+          create(:repository, public_access: true)
+        end
+        2.times do
+          repo = create(:repository, public_access: false)
+          repo.add_member(user, :read)
         end
       end
 
       context 'signed in as admin' do
-        subject { RepositoryPolicy.new(admin, public_repo) }
+        let(:current_user) { admin }
 
-        it 'allows to show the repository' do
-          expect(subject.show?).to be(true)
+        it 'returns all repositories' do
+          expect(subject.resolve.to_a.size).to eq(7)
+        end
+      end
+
+      context 'signed in as normal user' do
+        let(:current_user) { user }
+
+        it 'returns public repositories and ones with explicit access' do
+          expect(subject.resolve.to_a.size).to eq(5)
         end
       end
 
       context 'not signed in' do
-        subject { RepositoryPolicy.new(nil, public_repo) }
+        let(:current_user) { nil }
 
-        it 'allows to show the repository' do
-          expect(subject.show?).to be(true)
+        it 'returns only public repositories' do
+          expect(subject.resolve.to_a.size).to eq(3)
         end
       end
     end
 
-    context 'private repository' do
-      context 'not signed in' do
-        subject { RepositoryPolicy.new(nil, private_repo) }
+    context 'show?' do
+      context 'no repository' do
+        subject { RepositoryPolicy.new(user, nil) }
 
-        it 'does not allow to show the repository' do
+        it 'returns false' do
           expect(subject.show?).to be(false)
         end
       end
 
-      context 'signed in as admin' do
-        subject { RepositoryPolicy.new(admin, private_repo) }
-
-        it 'allows to show the repository' do
-          expect(subject.show?).to be(true)
-        end
-      end
-
-      context 'signed in as user without access' do
-        subject { RepositoryPolicy.new(user, private_repo) }
-
-        it 'does not allow to show the repository' do
-          expect(subject.show?).to be(false)
-        end
-      end
-
-      context 'signed in as user with access' do
-        context 'by ownership' do
-          let(:repository_by_user) do
-            create :repository, public_access: false, owner: user
-          end
-          subject { RepositoryPolicy.new(user, repository_by_user) }
+      context 'public repository' do
+        context 'signed in' do
+          subject { RepositoryPolicy.new(user, public_repo) }
 
           it 'allows to show the repository' do
             expect(subject.show?).to be(true)
           end
         end
 
-        context 'by repository membership' do
-          subject { RepositoryPolicy.new(user, private_repo) }
-
-          %w(admin write read).each do |role|
-            it "with role #{role} allows to show the repository" do
-              private_repo.add_member(user, role)
-              expect(subject.show?).to be(true)
-            end
-          end
-        end
-
-        context 'by organization membership' do
-          let(:repository_by_organization) do
-            create :repository, public_access: false, owner: organization
-          end
-          subject do
-            RepositoryPolicy.new(user, repository_by_organization)
-          end
-
-          %w(admin write read).each do |role|
-            it "with role #{role} allows to show the repository" do
-              organization.add_member(user, role)
-              expect(subject.show?).to be(true)
-            end
-          end
-        end
-      end
-    end
-  end
-
-  context 'create?' do
-    context 'owner is current user' do
-      context 'not signed in' do
-        subject { RepositoryPolicy.new(nil, public_repo) }
-
-        it 'does not allow to create the repository' do
-          expect(subject.create?(nil)).to be(false)
-        end
-      end
-
-      context 'signed in' do
-        context 'as admin role' do
+        context 'signed in as admin' do
           subject { RepositoryPolicy.new(admin, public_repo) }
 
-          it 'allows to create the repository' do
-            expect(subject.create?(admin)).to be(true)
+          it 'allows to show the repository' do
+            expect(subject.show?).to be(true)
           end
         end
-
-        context 'as user role' do
-          subject { RepositoryPolicy.new(user, public_repo) }
-
-          it 'allows to create the repository' do
-            expect(subject.create?(user)).to be(true)
-          end
-        end
-      end
-    end
-
-    context 'owner is organization' do
-      subject { RepositoryPolicy.new(user, Repository) }
-
-      %w(write read).each do |role|
-        it "with role #{role} does not allow to create the repository" do
-          organization.add_member(user, role)
-          expect(subject.create?(organization)).to be(false)
-        end
-      end
-
-      context 'as an organization admin' do
-        it 'allows to create the repository' do
-          organization.add_member(user, 'admin')
-          expect(subject.create?(organization)).to be(true)
-        end
-      end
-
-      context 'unrelated to the organization' do
-        it 'does not allow to create the repository' do
-          expect(subject.create?(organization)).to be(false)
-        end
-      end
-    end
-
-    context 'owner does not exist' do
-      subject { RepositoryPolicy.new(user, Repository) }
-
-      it 'does not allow to create the repository' do
-        expect(subject.create?(nil)).to be(false)
-      end
-    end
-  end
-
-  context 'update?' do
-    [true, false].each do |public|
-      context "with public access #{public}" do
-        let(:repository) { create :repository, public_access: public }
 
         context 'not signed in' do
-          subject { RepositoryPolicy.new(nil, repository) }
+          subject { RepositoryPolicy.new(nil, public_repo) }
 
-          it 'does not allow to update the repository' do
-            expect(subject.update?).to be(false)
+          it 'allows to show the repository' do
+            expect(subject.show?).to be(true)
+          end
+        end
+      end
+
+      context 'private repository' do
+        context 'not signed in' do
+          subject { RepositoryPolicy.new(nil, private_repo) }
+
+          it 'does not allow to show the repository' do
+            expect(subject.show?).to be(false)
+          end
+        end
+
+        context 'signed in as admin' do
+          subject { RepositoryPolicy.new(admin, private_repo) }
+
+          it 'allows to show the repository' do
+            expect(subject.show?).to be(true)
+          end
+        end
+
+        context 'signed in as user without access' do
+          subject { RepositoryPolicy.new(user, private_repo) }
+
+          it 'does not allow to show the repository' do
+            expect(subject.show?).to be(false)
+          end
+        end
+
+        context 'signed in as user with access' do
+          context 'by ownership' do
+            let(:repository_by_user) do
+              create :repository, public_access: false, owner: user
+            end
+            subject { RepositoryPolicy.new(user, repository_by_user) }
+
+            it 'allows to show the repository' do
+              expect(subject.show?).to be(true)
+            end
+          end
+
+          context 'by repository membership' do
+            subject { RepositoryPolicy.new(user, private_repo) }
+
+            %w(admin write read).each do |role|
+              it "with role #{role} allows to show the repository" do
+                private_repo.add_member(user, role)
+                expect(subject.show?).to be(true)
+              end
+            end
+          end
+
+          context 'by organization membership' do
+            let(:repository_by_organization) do
+              create :repository, public_access: false, owner: organization
+            end
+            subject do
+              RepositoryPolicy.new(user, repository_by_organization)
+            end
+
+            %w(admin write read).each do |role|
+              it "with role #{role} allows to show the repository" do
+                organization.add_member(user, role)
+                expect(subject.show?).to be(true)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'create?' do
+      context 'owner is current user' do
+        context 'not signed in' do
+          subject { RepositoryPolicy.new(nil, public_repo) }
+
+          it 'does not allow to create the repository' do
+            expect(subject.create?(nil)).to be(false)
           end
         end
 
         context 'signed in' do
           context 'as admin role' do
-            subject { RepositoryPolicy.new(admin, repository) }
+            subject { RepositoryPolicy.new(admin, public_repo) }
 
-            it 'allows to update the repository' do
-              expect(subject.update?).to be(true)
+            it 'allows to create the repository' do
+              expect(subject.create?(admin)).to be(true)
             end
           end
 
-          context 'as user role without access' do
-            subject { RepositoryPolicy.new(user, repository) }
+          context 'as user role' do
+            subject { RepositoryPolicy.new(user, public_repo) }
+
+            it 'allows to create the repository' do
+              expect(subject.create?(user)).to be(true)
+            end
+          end
+        end
+      end
+
+      context 'owner is organization' do
+        subject { RepositoryPolicy.new(user, Repository) }
+
+        %w(write read).each do |role|
+          it "with role #{role} does not allow to create the repository" do
+            organization.add_member(user, role)
+            expect(subject.create?(organization)).to be(false)
+          end
+        end
+
+        context 'as an organization admin' do
+          it 'allows to create the repository' do
+            organization.add_member(user, 'admin')
+            expect(subject.create?(organization)).to be(true)
+          end
+        end
+
+        context 'unrelated to the organization' do
+          it 'does not allow to create the repository' do
+            expect(subject.create?(organization)).to be(false)
+          end
+        end
+      end
+
+      context 'owner does not exist' do
+        subject { RepositoryPolicy.new(user, Repository) }
+
+        it 'does not allow to create the repository' do
+          expect(subject.create?(nil)).to be(false)
+        end
+      end
+    end
+
+    context 'update?' do
+      [true, false].each do |public|
+        context "with public access #{public}" do
+          let(:repository) { create :repository, public_access: public }
+
+          context 'not signed in' do
+            subject { RepositoryPolicy.new(nil, repository) }
 
             it 'does not allow to update the repository' do
               expect(subject.update?).to be(false)
             end
           end
 
-          context 'as a user role with access' do
-            context 'by ownership' do
-              let(:repository_by_user) do
-                create :repository, owner: user
-              end
-              subject { RepositoryPolicy.new(user, repository_by_user) }
+          context 'signed in' do
+            context 'as admin role' do
+              subject { RepositoryPolicy.new(admin, repository) }
 
               it 'allows to update the repository' do
                 expect(subject.update?).to be(true)
               end
             end
 
-            context 'by repository membership' do
+            context 'as user role without access' do
               subject { RepositoryPolicy.new(user, repository) }
 
-              %w(write read).each do |role|
-                it "with role #{role} does not allow to update the "\
-                  'repository' do
-                  repository.add_member(user, role)
-                  expect(subject.update?).to be(false)
-                end
-              end
-
-              it 'with role admin allows to update the repository' do
-                repository.add_member(user, 'admin')
-                expect(subject.update?).to be(true)
+              it 'does not allow to update the repository' do
+                expect(subject.update?).to be(false)
               end
             end
 
-            context 'by organization membership' do
-              let(:repository_by_organization) do
-                create :repository, owner: organization
-              end
-              subject do
-                RepositoryPolicy.new(user, repository_by_organization)
-              end
+            context 'as a user role with access' do
+              context 'by ownership' do
+                let(:repository_by_user) do
+                  create :repository, owner: user
+                end
+                subject { RepositoryPolicy.new(user, repository_by_user) }
 
-              %w(write read).each do |role|
-                it "with role #{role} does not allow to update the "\
-                  'repository' do
-                  organization.add_member(user, role)
-                  expect(subject.update?).to be(false)
+                it 'allows to update the repository' do
+                  expect(subject.update?).to be(true)
                 end
               end
 
-              it 'with role admin allows to update the repository' do
-                organization.add_member(user, 'admin')
-                expect(subject.update?).to be(true)
+              context 'by repository membership' do
+                subject { RepositoryPolicy.new(user, repository) }
+
+                %w(write read).each do |role|
+                  it "with role #{role} does not allow to update the "\
+                    'repository' do
+                    repository.add_member(user, role)
+                    expect(subject.update?).to be(false)
+                  end
+                end
+
+                it 'with role admin allows to update the repository' do
+                  repository.add_member(user, 'admin')
+                  expect(subject.update?).to be(true)
+                end
+              end
+
+              context 'by organization membership' do
+                let(:repository_by_organization) do
+                  create :repository, owner: organization
+                end
+                subject do
+                  RepositoryPolicy.new(user, repository_by_organization)
+                end
+
+                %w(write read).each do |role|
+                  it "with role #{role} does not allow to update the "\
+                    'repository' do
+                    organization.add_member(user, role)
+                    expect(subject.update?).to be(false)
+                  end
+                end
+
+                it 'with role admin allows to update the repository' do
+                  organization.add_member(user, 'admin')
+                  expect(subject.update?).to be(true)
+                end
               end
             end
           end
         end
       end
     end
-  end
 
-  context 'index?' do
-    [true, false].each do |public|
-      context "with public access #{public}" do
-        let(:repository) { create :repository, public_access: public }
+    context 'index?' do
+      [true, false].each do |public|
+        context "with public access #{public}" do
+          let(:repository) { create :repository, public_access: public }
 
-        context 'not signed in' do
-          subject { RepositoryPolicy.new(nil, repository) }
-
-          it 'allows to list the repository' do
-            expect(subject.index?).to be(true)
-          end
-        end
-
-        context 'signed in' do
-          context 'as user role' do
-            subject { RepositoryPolicy.new(user, repository) }
+          context 'not signed in' do
+            subject { RepositoryPolicy.new(nil, repository) }
 
             it 'allows to list the repository' do
               expect(subject.index?).to be(true)
             end
           end
 
-          context 'as admin role' do
-            subject { RepositoryPolicy.new(admin, repository) }
+          context 'signed in' do
+            context 'as user role' do
+              subject { RepositoryPolicy.new(user, repository) }
 
-            it 'allows to list the repository' do
-              expect(subject.index?).to be(true)
+              it 'allows to list the repository' do
+                expect(subject.index?).to be(true)
+              end
+            end
+
+            context 'as admin role' do
+              subject { RepositoryPolicy.new(admin, repository) }
+
+              it 'allows to list the repository' do
+                expect(subject.index?).to be(true)
+              end
             end
           end
         end
       end
     end
-  end
 
-  context 'write?' do
-    [true, false].each do |public_access|
-      context "with public access #{public_access}" do
-        let(:repository) { create :repository, public_access: public_access }
+    context 'write?' do
+      [true, false].each do |public_access|
+        context "with public access #{public_access}" do
+          let(:repository) { create :repository, public_access: public_access }
 
-        context 'not signed in' do
-          subject { RepositoryPolicy.new(nil, repository) }
-
-          it 'does not allow to write to the repository' do
-            expect(subject.write?).to be(false)
-          end
-        end
-
-        context 'signed in' do
-          context 'as admin role' do
-            subject { RepositoryPolicy.new(admin, repository) }
-
-            it 'allows to write to the repository' do
-              expect(subject.write?).to be(true)
-            end
-          end
-
-          context 'as a user role without access' do
-            subject { RepositoryPolicy.new(user, repository) }
+          context 'not signed in' do
+            subject { RepositoryPolicy.new(nil, repository) }
 
             it 'does not allow to write to the repository' do
               expect(subject.write?).to be(false)
             end
           end
 
-          context 'as a user role with access' do
-            context 'by ownership' do
-              let(:repository_by_user) do
-                create :repository, owner: user
-              end
-              subject { RepositoryPolicy.new(user, repository_by_user) }
+          context 'signed in' do
+            context 'as admin role' do
+              subject { RepositoryPolicy.new(admin, repository) }
 
               it 'allows to write to the repository' do
                 expect(subject.write?).to be(true)
               end
             end
 
-            context 'by repository membership' do
+            context 'as a user role without access' do
               subject { RepositoryPolicy.new(user, repository) }
 
-              %w(admin write).each do |role|
-                it "with role #{role} allows to write to the "\
-                  'repository' do
-                  repository.add_member(user, role)
-                  expect(subject.write?).to be(true)
-                end
-              end
-
-              it 'with role read does not allow to write the repository' do
-                repository.add_member(user, 'read')
+              it 'does not allow to write to the repository' do
                 expect(subject.write?).to be(false)
               end
             end
 
-            context 'by organization membership' do
-              let(:repository_by_organization) do
-                create :repository, owner: organization
-              end
-              subject do
-                RepositoryPolicy.new(user, repository_by_organization)
-              end
+            context 'as a user role with access' do
+              context 'by ownership' do
+                let(:repository_by_user) do
+                  create :repository, owner: user
+                end
+                subject { RepositoryPolicy.new(user, repository_by_user) }
 
-              %w(admin write).each do |role|
-                it "with role #{role} allows to write to the "\
-                  'repository' do
-                  organization.add_member(user, role)
+                it 'allows to write to the repository' do
                   expect(subject.write?).to be(true)
                 end
               end
 
-              it 'with role read does not allow to write to the repository' do
-                organization.add_member(user, 'read')
-                expect(subject.write?).to be(false)
+              context 'by repository membership' do
+                subject { RepositoryPolicy.new(user, repository) }
+
+                %w(admin write).each do |role|
+                  it "with role #{role} allows to write to the "\
+                    'repository' do
+                    repository.add_member(user, role)
+                    expect(subject.write?).to be(true)
+                  end
+                end
+
+                it 'with role read does not allow to write the repository' do
+                  repository.add_member(user, 'read')
+                  expect(subject.write?).to be(false)
+                end
+              end
+
+              context 'by organization membership' do
+                let(:repository_by_organization) do
+                  create :repository, owner: organization
+                end
+                subject do
+                  RepositoryPolicy.new(user, repository_by_organization)
+                end
+
+                %w(admin write).each do |role|
+                  it "with role #{role} allows to write to the "\
+                    'repository' do
+                    organization.add_member(user, role)
+                    expect(subject.write?).to be(true)
+                  end
+                end
+
+                it 'with role read does not allow to write to the repository' do
+                  organization.add_member(user, 'read')
+                  expect(subject.write?).to be(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'destroy?' do
+      [true, false].each do |public_access|
+        context "with public access #{public_access}" do
+          let(:repository) { create :repository, public_access: public_access }
+
+          context 'not signed in' do
+            subject { RepositoryPolicy.new(nil, repository) }
+
+            it 'does not allow to destroy the repository' do
+              expect(subject.destroy?).to be(false)
+            end
+          end
+
+          context 'signed in' do
+            context 'as admin role' do
+              subject { RepositoryPolicy.new(admin, repository) }
+
+              it 'allows to destroy the repository' do
+                expect(subject.destroy?).to be(true)
+              end
+            end
+
+            context 'as user role without access' do
+              subject { RepositoryPolicy.new(user, repository) }
+
+              it 'does not allow to destroy the repository' do
+                expect(subject.destroy?).to be(false)
+              end
+            end
+
+            context 'as a user role with access' do
+              context 'by ownership' do
+                let(:repository_by_user) do
+                  create :repository, owner: user
+                end
+                subject { RepositoryPolicy.new(user, repository_by_user) }
+
+                it 'allows to destroy the repository' do
+                  expect(subject.destroy?).to be(true)
+                end
+              end
+
+              context 'by repository membership' do
+                subject { RepositoryPolicy.new(user, repository) }
+
+                %w(write read).each do |role|
+                  it "with role #{role} does not allow to destroy the "\
+                    'repository' do
+                    repository.add_member(user, role)
+                    expect(subject.destroy?).to be(false)
+                  end
+                end
+
+                it 'with role admin allows to destroy the repository' do
+                  repository.add_member(user, 'admin')
+                  expect(subject.destroy?).to be(true)
+                end
+              end
+
+              context 'by organization membership' do
+                let(:repository_by_organization) do
+                  create :repository, owner: organization
+                end
+                subject do
+                  RepositoryPolicy.new(user, repository_by_organization)
+                end
+
+                %w(write read).each do |role|
+                  it "with role #{role} does not allow to destroy the "\
+                    'repository' do
+                    organization.add_member(user, role)
+                    expect(subject.destroy?).to be(false)
+                  end
+                end
+
+                it 'with role admin allows to destroy the repository' do
+                  organization.add_member(user, 'admin')
+                  expect(subject.destroy?).to be(true)
+                end
               end
             end
           end
@@ -421,89 +509,36 @@ RSpec.describe RepositoryPolicy do
     end
   end
 
-  context 'destroy?' do
-    [true, false].each do |public_access|
-      context "with public access #{public_access}" do
-        let(:repository) { create :repository, public_access: public_access }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { RepositoryPolicy.new(current_user) }
 
-        context 'not signed in' do
-          subject { RepositoryPolicy.new(nil, repository) }
+    describe RepositoryPolicy::Scope do
+      subject { RepositoryPolicy::Scope.new(current_user, scope) }
+      let(:scope) { Repository.dataset }
 
-          it 'does not allow to destroy the repository' do
-            expect(subject.destroy?).to be(false)
-          end
+      before do
+        2.times do
+          create(:repository, public_access: false)
         end
-
-        context 'signed in' do
-          context 'as admin role' do
-            subject { RepositoryPolicy.new(admin, repository) }
-
-            it 'allows to destroy the repository' do
-              expect(subject.destroy?).to be(true)
-            end
-          end
-
-          context 'as user role without access' do
-            subject { RepositoryPolicy.new(user, repository) }
-
-            it 'does not allow to destroy the repository' do
-              expect(subject.destroy?).to be(false)
-            end
-          end
-
-          context 'as a user role with access' do
-            context 'by ownership' do
-              let(:repository_by_user) do
-                create :repository, owner: user
-              end
-              subject { RepositoryPolicy.new(user, repository_by_user) }
-
-              it 'allows to destroy the repository' do
-                expect(subject.destroy?).to be(true)
-              end
-            end
-
-            context 'by repository membership' do
-              subject { RepositoryPolicy.new(user, repository) }
-
-              %w(write read).each do |role|
-                it "with role #{role} does not allow to destroy the "\
-                  'repository' do
-                  repository.add_member(user, role)
-                  expect(subject.destroy?).to be(false)
-                end
-              end
-
-              it 'with role admin allows to destroy the repository' do
-                repository.add_member(user, 'admin')
-                expect(subject.destroy?).to be(true)
-              end
-            end
-
-            context 'by organization membership' do
-              let(:repository_by_organization) do
-                create :repository, owner: organization
-              end
-              subject do
-                RepositoryPolicy.new(user, repository_by_organization)
-              end
-
-              %w(write read).each do |role|
-                it "with role #{role} does not allow to destroy the "\
-                  'repository' do
-                  organization.add_member(user, role)
-                  expect(subject.destroy?).to be(false)
-                end
-              end
-
-              it 'with role admin allows to destroy the repository' do
-                organization.add_member(user, 'admin')
-                expect(subject.destroy?).to be(true)
-              end
-            end
-          end
+        3.times do
+          create(:repository, public_access: true)
         end
       end
+
+      it 'returns all repositories' do
+        expect(subject.resolve.to_a.size).to eq(5)
+      end
+    end
+
+    %i(create? update? index? destroy? write?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
+      end
+    end
+
+    it 'does allow show?' do
+      expect(subject.show?).to be(true)
     end
   end
 end

--- a/spec/policies/search_result_policy_spec.rb
+++ b/spec/policies/search_result_policy_spec.rb
@@ -3,31 +3,44 @@
 require 'rails_helper'
 
 RSpec.describe SearchResultPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'search?' do
-    context 'signed in' do
-      subject { SearchResultPolicy.new(user) }
+    context 'search?' do
+      context 'signed in' do
+        subject { SearchResultPolicy.new(user) }
 
-      it 'allows to search' do
-        expect(subject.search?).to be(true)
+        it 'allows to search' do
+          expect(subject.search?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { SearchResultPolicy.new(admin) }
+
+        it 'allows to search' do
+          expect(subject.search?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { SearchResultPolicy.new(nil) }
+
+        it 'allows to search' do
+          expect(subject.search?).to be(true)
+        end
       end
     end
+  end
 
-    context 'signed in as admin' do
-      subject { SearchResultPolicy.new(admin) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { SearchResultPolicy.new(current_user) }
 
-      it 'allows to search' do
-        expect(subject.search?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { SearchResultPolicy.new(nil) }
-
-      it 'allows to search' do
-        expect(subject.search?).to be(true)
+    %i(search?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
   end

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -3,31 +3,44 @@
 require 'rails_helper'
 
 RSpec.describe SessionPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'create?' do
-    context 'not signed in' do
-      subject { SessionPolicy.new(nil) }
+    context 'create?' do
+      context 'not signed in' do
+        subject { SessionPolicy.new(nil) }
 
-      it 'allows to sign in' do
-        expect(subject.create?).to be(true)
+        it 'allows to sign in' do
+          expect(subject.create?).to be(true)
+        end
+      end
+
+      context 'signed in as user' do
+        subject { SessionPolicy.new(user) }
+
+        it 'does not allow to sign in' do
+          expect(subject.create?).to be(false)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { SessionPolicy.new(admin) }
+
+        it 'allows to sign in (makes no sense, but admin is god)' do
+          expect(subject.create?).to be(true)
+        end
       end
     end
+  end
 
-    context 'signed in as user' do
-      subject { SessionPolicy.new(user) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { SessionPolicy.new(current_user) }
 
-      it 'does not allow to sign in' do
-        expect(subject.create?).to be(false)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { SessionPolicy.new(admin) }
-
-      it 'allows to sign in (makes no sense, but admin is god)' do
-        expect(subject.create?).to be(true)
+    %i(create?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
   end

--- a/spec/policies/unlock_policy_spec.rb
+++ b/spec/policies/unlock_policy_spec.rb
@@ -3,57 +3,70 @@
 require 'rails_helper'
 
 RSpec.describe UnlockPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'resend_unlocking_email?' do
-    context 'signed in' do
-      subject { UnlockPolicy.new(user) }
+    context 'resend_unlocking_email?' do
+      context 'signed in' do
+        subject { UnlockPolicy.new(user) }
 
-      it 'allows to resend the unlocking email' do
-        expect(subject.resend_unlocking_email?).to be(true)
+        it 'allows to resend the unlocking email' do
+          expect(subject.resend_unlocking_email?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { UnlockPolicy.new(admin) }
+
+        it 'allows to resend the unlocking email' do
+          expect(subject.resend_unlocking_email?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { UnlockPolicy.new(nil) }
+
+        it 'allows to resend the unlocking email' do
+          expect(subject.resend_unlocking_email?).to be(true)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { UnlockPolicy.new(admin) }
+    context 'unlock_account?' do
+      context 'signed in' do
+        subject { UnlockPolicy.new(user) }
 
-      it 'allows to resend the unlocking email' do
-        expect(subject.resend_unlocking_email?).to be(true)
+        it 'allows to unlock the account' do
+          expect(subject.unlock_account?).to be(true)
+        end
       end
-    end
 
-    context 'not signed in' do
-      subject { UnlockPolicy.new(nil) }
+      context 'signed in as admin' do
+        subject { UnlockPolicy.new(admin) }
 
-      it 'allows to resend the unlocking email' do
-        expect(subject.resend_unlocking_email?).to be(true)
+        it 'allows to unlock the account' do
+          expect(subject.unlock_account?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { UnlockPolicy.new(nil) }
+
+        it 'allows to unlock the account' do
+          expect(subject.unlock_account?).to be(true)
+        end
       end
     end
   end
 
-  context 'unlock_account?' do
-    context 'signed in' do
-      subject { UnlockPolicy.new(user) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { UnlockPolicy.new(current_user) }
 
-      it 'allows to unlock the account' do
-        expect(subject.unlock_account?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { UnlockPolicy.new(admin) }
-
-      it 'allows to unlock the account' do
-        expect(subject.unlock_account?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { UnlockPolicy.new(nil) }
-
-      it 'allows to unlock the account' do
-        expect(subject.unlock_account?).to be(true)
+    %i(resend_unlocking_email? unlock_account?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,95 +3,112 @@
 require 'rails_helper'
 
 RSpec.describe UserPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
-  let(:other_user) { create :user }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
+    let(:other_user) { create :user }
 
-  context 'show?' do
-    context 'signed in' do
-      subject { UserPolicy.new(user, other_user) }
+    context 'show?' do
+      context 'signed in' do
+        subject { UserPolicy.new(user, other_user) }
 
-      it 'allows to show the user' do
-        expect(subject.show?).to be(true)
+        it 'allows to show the user' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { UserPolicy.new(admin, other_user) }
+
+        it 'allows to show the user' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { UserPolicy.new(nil, other_user) }
+
+        it 'allows to show the user' do
+          expect(subject.show?).to be(true)
+        end
       end
     end
 
-    context 'signed in as admin' do
-      subject { UserPolicy.new(admin, other_user) }
+    context 'show_current_user?' do
+      context 'signed in' do
+        subject { UserPolicy.new(user, other_user) }
 
-      it 'allows to show the user' do
-        expect(subject.show?).to be(true)
+        it 'allows to show the user' do
+          expect(subject.show_current_user?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { UserPolicy.new(admin, other_user) }
+
+        it 'allows to show the user' do
+          expect(subject.show_current_user?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { UserPolicy.new(nil, other_user) }
+
+        it 'does not allow to show the user' do
+          expect(subject.show_current_user?).to be(false)
+        end
       end
     end
 
-    context 'not signed in' do
-      subject { UserPolicy.new(nil, other_user) }
+    context 'access_private_data?' do
+      context 'signed in as admin' do
+        subject { UserPolicy.new(admin, other_user) }
 
-      it 'allows to show the user' do
-        expect(subject.show?).to be(true)
-      end
-    end
-  end
-
-  context 'show_current_user?' do
-    context 'signed in' do
-      subject { UserPolicy.new(user, other_user) }
-
-      it 'allows to show the user' do
-        expect(subject.show_current_user?).to be(true)
-      end
-    end
-
-    context 'signed in as admin' do
-      subject { UserPolicy.new(admin, other_user) }
-
-      it 'allows to show the user' do
-        expect(subject.show_current_user?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { UserPolicy.new(nil, other_user) }
-
-      it 'does not allow to show the user' do
-        expect(subject.show_current_user?).to be(false)
-      end
-    end
-  end
-
-  context 'access_private_data?' do
-    context 'signed in as admin' do
-      subject { UserPolicy.new(admin, other_user) }
-
-      it 'allows to see the users private data' do
-        expect(subject.access_private_data?).to be(true)
-      end
-    end
-
-    context 'signed in' do
-      context 'own email' do
-        subject { UserPolicy.new(user, user) }
-
-        it 'allows to see my private data' do
+        it 'allows to see the users private data' do
           expect(subject.access_private_data?).to be(true)
         end
       end
 
-      context 'other users email' do
-        subject { UserPolicy.new(user, other_user) }
+      context 'signed in' do
+        context 'own email' do
+          subject { UserPolicy.new(user, user) }
+
+          it 'allows to see my private data' do
+            expect(subject.access_private_data?).to be(true)
+          end
+        end
+
+        context 'other users email' do
+          subject { UserPolicy.new(user, other_user) }
+
+          it 'does not allow to see the users private data' do
+            expect(subject.access_private_data?).to be(false)
+          end
+        end
+      end
+
+      context 'not signed in' do
+        subject { UserPolicy.new(nil, other_user) }
 
         it 'does not allow to see the users private data' do
           expect(subject.access_private_data?).to be(false)
         end
       end
     end
+  end
 
-    context 'not signed in' do
-      subject { UserPolicy.new(nil, other_user) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { UserPolicy.new(current_user) }
 
-      it 'does not allow to see the users private data' do
-        expect(subject.access_private_data?).to be(false)
+    %i(show_current_user? access_private_data?).each do |method|
+      it "does not allow #{method}" do
+        expect(subject.public_send(method)).to be(false)
       end
+    end
+
+    it 'does allow show?' do
+      expect(subject.show?).to be(true)
     end
   end
 end

--- a/spec/policies/version_policy_spec.rb
+++ b/spec/policies/version_policy_spec.rb
@@ -3,32 +3,43 @@
 require 'rails_helper'
 
 RSpec.describe VersionPolicy do
-  let(:user) { create :user }
-  let(:admin) { create :user, :admin }
+  context 'when current_user is a User' do
+    let(:user) { create :user }
+    let(:admin) { create :user, :admin }
 
-  context 'show?' do
-    context 'signed in' do
-      subject { VersionPolicy.new(user) }
+    context 'show?' do
+      context 'signed in' do
+        subject { VersionPolicy.new(user) }
 
-      it 'allows to show the version' do
-        expect(subject.show?).to be(true)
+        it 'allows to show the version' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'signed in as admin' do
+        subject { VersionPolicy.new(admin) }
+
+        it 'allows to show the version' do
+          expect(subject.show?).to be(true)
+        end
+      end
+
+      context 'not signed in' do
+        subject { VersionPolicy.new(nil) }
+
+        it 'allows to show the version' do
+          expect(subject.show?).to be(true)
+        end
       end
     end
+  end
 
-    context 'signed in as admin' do
-      subject { VersionPolicy.new(admin) }
+  context 'when current_user is an ApiKey' do
+    let(:current_user) { create(:api_key) }
+    subject { VersionPolicy.new(current_user) }
 
-      it 'allows to show the version' do
-        expect(subject.show?).to be(true)
-      end
-    end
-
-    context 'not signed in' do
-      subject { VersionPolicy.new(nil) }
-
-      it 'allows to show the version' do
-        expect(subject.show?).to be(true)
-      end
+    it 'does allow show?' do
+      expect(subject.show?).to be(true)
     end
   end
 end

--- a/spec/support/controller_login_helpers.rb
+++ b/spec/support/controller_login_helpers.rb
@@ -29,6 +29,15 @@ module ControllerLoginHelpers
       token = JWTWrapper.encode(payload)
       request.env['HTTP_AUTHORIZATION'] = "Bearer #{token}"
     end
+
+    def create_api_key_and_set_header
+      raw_key ||= SecureRandom.hex(80)
+      request.env['HTTP_AUTHORIZATION'] = "ApiKey #{raw_key}"
+      encoded_key =
+        ApiKey.digest(Rails.application.secrets.api_key_base, raw_key)
+      api_key = ApiKey.create(key: encoded_key, comment: 'test key')
+      {api_key: api_key, raw: raw_key}
+    end
   end
 end
 


### PR DESCRIPTION
Closes #181. Depends on https://github.com/ontohub/ontohub-models/pull/125.

The policy specs all remain the same except for indentation and the addition of a new context at the bottom.