### PR TITLE
Initialize Faker with RSpec seed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,4 +69,6 @@ RSpec.configure do |config|
 
   # Configure faker to use the RSpec seed
   Faker::Config.random = Random.new(config.seed)
+  # Configure ruby to use the RSpec seed for randomization
+  srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,4 +66,7 @@ RSpec.configure do |config|
   config.fuubar_progress_bar_options = {format: '[%B] %c/%C',
                                         progress_mark: '#',
                                         remainder_mark: '-'}
+
+  # Configure faker to use the RSpec seed
+  Faker::Config.random = Random.new(config.seed)
 end


### PR DESCRIPTION
This makes Faker produce the same values for the same RSpec seed, which makes debugging factory issues easier. The second commit does the same for Ruby's random generator, so `sample`, `shuffle`, `rand`, etc. should all produce deterministic results given the same rspec seed.