### PR TITLE
Replace find by first.

### DIFF
--- a/app/controllers/rest/documents_controller.rb
+++ b/app/controllers/rest/documents_controller.rb
@@ -38,7 +38,7 @@ module Rest
       QUERY
 
       plain do |_graphql_executor, variables, _context|
-        repository = RepositoryCompound.find(slug: variables['repository'])
+        repository = RepositoryCompound.first(slug: variables['repository'])
         git = repository.git
         commit = git.commit(variables['revision'] || git.default_branch)
         document =

--- a/app/graphql/mutations/account/remove_public_key_mutation.rb
+++ b/app/graphql/mutations/account/remove_public_key_mutation.rb
@@ -23,7 +23,7 @@ module Mutations
     # GraphQL mutation to remove a public key
     class RemovePublicKeyResolver
       def call(user, arguments, _context)
-        key = PublicKey.find(user_id: user.id, name: arguments[:name].strip)
+        key = PublicKey.first(user_id: user.id, name: arguments[:name].strip)
 
         raise GraphQL::ExecutionError, 'Public key not found' unless key
 

--- a/app/graphql/mutations/organization/delete_organization_mutation.rb
+++ b/app/graphql/mutations/organization/delete_organization_mutation.rb
@@ -14,7 +14,7 @@ module Mutations
       end
 
       resource!(lambda do |_root, arguments, _context|
-        ::Organization.find(slug: arguments[:slug])
+        ::Organization.first(slug: arguments[:slug])
       end)
 
       authorize! :destroy

--- a/app/graphql/mutations/organization/save_organization_mutation.rb
+++ b/app/graphql/mutations/organization/save_organization_mutation.rb
@@ -15,7 +15,7 @@ module Mutations
       end
 
       resource!(lambda do |_root, arguments, _context|
-        ::Organization.find(slug: arguments[:slug])
+        ::Organization.first(slug: arguments[:slug])
       end)
 
       authorize! :update

--- a/app/graphql/mutations/repository/create_repository_mutation.rb
+++ b/app/graphql/mutations/repository/create_repository_mutation.rb
@@ -11,7 +11,7 @@ module Mutations
       end
 
       resource!(lambda do |_root, arguments, _context|
-        OrganizationalUnit.find(slug: arguments['data']['owner'])
+        OrganizationalUnit.first(slug: arguments['data']['owner'])
       end)
 
       authorize!(lambda do |owner, _arguments, context|

--- a/app/graphql/mutations/repository/delete_repository_mutation.rb
+++ b/app/graphql/mutations/repository/delete_repository_mutation.rb
@@ -11,7 +11,7 @@ module Mutations
       end
 
       resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.find(slug: arguments[:slug])
+        RepositoryCompound.first(slug: arguments[:slug])
       end)
 
       not_found_unless :show

--- a/app/graphql/mutations/repository/git/commit_mutation.rb
+++ b/app/graphql/mutations/repository/git/commit_mutation.rb
@@ -16,7 +16,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         not_found_unless :show

--- a/app/graphql/mutations/repository/git/create_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/create_branch_mutation.rb
@@ -20,7 +20,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         not_found_unless :show

--- a/app/graphql/mutations/repository/git/create_tag_mutation.rb
+++ b/app/graphql/mutations/repository/git/create_tag_mutation.rb
@@ -24,7 +24,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         authorize! :write, policy: :repository

--- a/app/graphql/mutations/repository/git/delete_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/delete_branch_mutation.rb
@@ -16,7 +16,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         not_found_unless :show

--- a/app/graphql/mutations/repository/git/delete_tag_mutation.rb
+++ b/app/graphql/mutations/repository/git/delete_tag_mutation.rb
@@ -16,7 +16,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         not_found_unless :show

--- a/app/graphql/mutations/repository/git/set_default_branch_mutation.rb
+++ b/app/graphql/mutations/repository/git/set_default_branch_mutation.rb
@@ -16,7 +16,7 @@ module Mutations
         end
 
         resource!(lambda do |_root, arguments, _context|
-          RepositoryCompound.find(slug: arguments['repositoryId'])
+          RepositoryCompound.first(slug: arguments['repositoryId'])
         end)
 
         not_found_unless :show

--- a/app/graphql/mutations/repository/save_repository_mutation.rb
+++ b/app/graphql/mutations/repository/save_repository_mutation.rb
@@ -15,7 +15,7 @@ module Mutations
       end
 
       resource!(lambda do |_root, arguments, _context|
-        RepositoryCompound.find(slug: arguments[:slug])
+        RepositoryCompound.first(slug: arguments[:slug])
       end)
 
       not_found_unless :show

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -20,7 +20,7 @@ Types::QueryType = GraphQL::ObjectType.define do
     end
 
     resolve(lambda do |_root, arguments, _context|
-      OrganizationalUnit.find(slug: arguments[:slug])
+      OrganizationalUnit.first(slug: arguments[:slug])
     end)
   end
 
@@ -34,7 +34,7 @@ Types::QueryType = GraphQL::ObjectType.define do
     authorize :show
 
     resource(lambda do |_root, arguments, _context|
-      RepositoryCompound.find(slug: arguments[:slug])
+      RepositoryCompound.first(slug: arguments[:slug])
     end)
 
     resolve ->(repo, _arguments, _context) { repo }

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -6,7 +6,7 @@ class UsersMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
 
   def initialize_from_record(user_id)
-    user = User.find(id: user_id)
+    user = User.first(id: user_id)
     @scope_name = :user
     @resource = instance_variable_set("@#{devise_mapping.name}", user)
   end

--- a/app/models/git_user.rb
+++ b/app/models/git_user.rb
@@ -10,6 +10,6 @@ class GitUser
   end
 
   def account
-    @account ||= User.find(email: email)
+    @account ||= User.first(email: email)
   end
 end

--- a/config/initializers/core_extensions/devise/strategies/json_web_token.rb
+++ b/config/initializers/core_extensions/devise/strategies/json_web_token.rb
@@ -8,7 +8,7 @@ module Devise
     class JsonWebToken < HttpAuthorization
       def authenticate!
         return unless claims&.key?('user_id')
-        success! User.find(
+        success! User.first(
           Sequel[:organizational_units][:slug] => claims['user_id']
         )
       end

--- a/db/seeds/021_organization_membership_seeds.rb
+++ b/db/seeds/021_organization_membership_seeds.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 # Fill seed user organization
-organization = Organization.find(slug: 'seed-user-organization')
-organization.add_member(User.find(slug: 'ada'), 'admin')
-organization.add_member(User.find(slug: 'bob'), 'admin')
-organization.add_member(User.find(slug: 'cam'), 'write')
-organization.add_member(User.find(slug: 'dan'), 'read')
-organization.add_member(User.find(slug: 'eva'), 'read')
+organization = Organization.first(slug: 'seed-user-organization')
+organization.add_member(User.first(slug: 'ada'), 'admin')
+organization.add_member(User.first(slug: 'bob'), 'admin')
+organization.add_member(User.first(slug: 'cam'), 'write')
+organization.add_member(User.first(slug: 'dan'), 'read')
+organization.add_member(User.first(slug: 'eva'), 'read')
 
 # Fill extraordinary organization
 extra_organization = Organization.
   find(slug: 'the-league-of-extraordinary-users')
-extra_organization.add_member(User.find(slug: 'ada'), 'admin')
-extra_organization.add_member(User.find(slug: 'bob'), 'admin')
-extra_organization.add_member(User.find(slug: 'cam'), 'write')
-extra_organization.add_member(User.find(slug: 'dan'), 'read')
+extra_organization.add_member(User.first(slug: 'ada'), 'admin')
+extra_organization.add_member(User.first(slug: 'bob'), 'admin')
+extra_organization.add_member(User.first(slug: 'cam'), 'write')
+extra_organization.add_member(User.first(slug: 'dan'), 'read')

--- a/db/seeds/030_repository_seeds.rb
+++ b/db/seeds/030_repository_seeds.rb
@@ -3,7 +3,7 @@
 # Create repositories.
 organization_fixtures_repo =
   RepositoryCompound.
-    new(owner: Organization.find(slug: 'seed-user-organization'),
+    new(owner: Organization.first(slug: 'seed-user-organization'),
         name: 'Fixtures',
         content_type: 'model',
         public_access: true,
@@ -12,7 +12,7 @@ organization_fixtures_repo.save
 
 ada_fixtures_repo =
   RepositoryCompound.
-    new(owner: User.find(slug: 'ada'),
+    new(owner: User.first(slug: 'ada'),
         name: 'Fixtures',
         content_type: 'specification',
         public_access: true,
@@ -21,7 +21,7 @@ ada_fixtures_repo.save
 
 organization_math_repo =
   RepositoryCompound.
-    new(owner: Organization.find(slug: 'seed-user-organization'),
+    new(owner: Organization.first(slug: 'seed-user-organization'),
         name: 'Math',
         content_type: 'mathematical',
         public_access: true,
@@ -30,7 +30,7 @@ organization_math_repo.save
 
 top_secret_repo =
   RepositoryCompound.
-    new(owner: Organization.find(slug: 'the-league-of-extraordinary-users'),
+    new(owner: Organization.first(slug: 'the-league-of-extraordinary-users'),
         name: 'Top Secret',
         content_type: 'ontology',
         public_access: false,

--- a/db/seeds/031_repository_membership_seeds.rb
+++ b/db/seeds/031_repository_membership_seeds.rb
@@ -2,11 +2,11 @@
 
 # Fill ada fixtures repository
 
-repo = Repository.find(slug: 'ada/fixtures')
-repo.add_member(User.find(slug: 'bob'), 'admin')
-repo.add_member(User.find(slug: 'cam'), 'write')
-repo.add_member(User.find(slug: 'dan'), 'read')
+repo = Repository.first(slug: 'ada/fixtures')
+repo.add_member(User.first(slug: 'bob'), 'admin')
+repo.add_member(User.first(slug: 'cam'), 'write')
+repo.add_member(User.first(slug: 'dan'), 'read')
 
 # Fill top secret repository
-Repository.find(slug: 'the-league-of-extraordinary-users/top-secret').
-  add_member(User.find(slug: 'eva'), 'read')
+Repository.first(slug: 'the-league-of-extraordinary-users/top-secret').
+  add_member(User.first(slug: 'eva'), 'read')

--- a/db/seeds/040_file_seeds.rb
+++ b/db/seeds/040_file_seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-repository = RepositoryCompound.wrap(Repository.find(slug: 'ada/fixtures'))
+repository = RepositoryCompound.wrap(Repository.first(slug: 'ada/fixtures'))
 
 # Commit new images
 %w(jpg png svg).each do |file_type|

--- a/db/seeds/045_document_seeds.rb
+++ b/db/seeds/045_document_seeds.rb
@@ -2,7 +2,7 @@
 
 documents = Rails.root.join('db/seeds/fixtures/documents')
 
-ada_fixtures_repo = RepositoryCompound.find(slug: 'ada/fixtures')
+ada_fixtures_repo = RepositoryCompound.first(slug: 'ada/fixtures')
 
 %w(Numbers.casl RelationsAndOrders.casl).each do |file|
   FactoryBot.
@@ -91,7 +91,7 @@ FactoryBot.
 # Create some Hets-lib files in a subdirectory, using a UrlMapping
 
 organization_fixtures_repo =
-  RepositoryCompound.find(slug: 'seed-user-organization/fixtures')
+  RepositoryCompound.first(slug: 'seed-user-organization/fixtures')
 
 UrlMapping.create(repository_id: organization_fixtures_repo.id,
                   source: 'Basic/',

--- a/db/seeds/050_branch_seeds.rb
+++ b/db/seeds/050_branch_seeds.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-repository = RepositoryCompound.wrap(Repository.find(slug: 'ada/fixtures'))
+repository = RepositoryCompound.wrap(Repository.first(slug: 'ada/fixtures'))
 repository.git.create_branch('new_feature', 'master')

--- a/db/seeds/060_tag_seeds.rb
+++ b/db/seeds/060_tag_seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-repository = RepositoryCompound.wrap(Repository.find(slug: 'ada/fixtures'))
+repository = RepositoryCompound.wrap(Repository.first(slug: 'ada/fixtures'))
 repository.git.create_tag('1.0', 'master')
 repository.git.create_tag('1.1', 'master',
                           message: 'my first annotated tag',

--- a/db/seeds/070_ssh_seeds.rb
+++ b/db/seeds/070_ssh_seeds.rb
@@ -4,5 +4,5 @@ public_key = <<~KEY
   ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIvfRuF3YhtXWp22cwb6Ain6cpCS8UzfEgw72LDR8jPP
 KEY
 name = 'ssh fixture public key'
-user = User.find(slug: 'ada')
+user = User.first(slug: 'ada')
 PublicKey.new(name: name, key: public_key.strip, user_id: user.id).save

--- a/lib/file_version_parents_creator.rb
+++ b/lib/file_version_parents_creator.rb
@@ -8,14 +8,14 @@ class FileVersionParentsCreator
 
   def initialize(repository_id, commit_sha)
     @commit_sha = commit_sha
-    @repository = RepositoryCompound.find(id: repository_id)
+    @repository = RepositoryCompound.first(id: repository_id)
     @git = @repository.git
   end
 
   def call
     git.ls_files(commit_sha).each do |filepath|
       target_sha = git.log(ref: commit_sha, path: filepath, limit: 1).first.id
-      file_version = FileVersion.find(path: filepath, commit_sha: target_sha)
+      file_version = FileVersion.first(path: filepath, commit_sha: target_sha)
       FileVersionParent.create(queried_sha: commit_sha,
                                last_changed_file_version: file_version)
     end

--- a/lib/importing_documents_reanalyzer.rb
+++ b/lib/importing_documents_reanalyzer.rb
@@ -57,8 +57,8 @@ class ImportingDocumentsReanalyzer
     target_sha = git.log(ref: commit_sha, path: file_path, limit: 2)[1]&.id
     return nil if target_sha.nil?
 
-    previous_file_version = FileVersion.find(path: file_path,
-                                             commit_sha: target_sha)
+    previous_file_version = FileVersion.first(path: file_path,
+                                              commit_sha: target_sha)
     Document.first(file_version_id: previous_file_version&.id)
   end
 

--- a/spec/controllers/rest/documents_controller_spec.rb
+++ b/spec/controllers/rest/documents_controller_spec.rb
@@ -15,9 +15,9 @@ RSpec.shared_examples 'a REST DocumentsController' do
       end
     end
     let(:file_version) do
-      FileVersion.find(commit_sha: commit_sha,
-                       path: file_path,
-                       repository_id: repository.id)
+      FileVersion.first(commit_sha: commit_sha,
+                        path: file_path,
+                        repository_id: repository.id)
     end
     let(:document) { create(document_factory, file_version: file_version) }
     let(:loc_id) { document.loc_id }

--- a/spec/graphql/mutations/account/delete_account_mutation_spec.rb
+++ b/spec/graphql/mutations/account/delete_account_mutation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Mutations::Account::DeleteAccountMutation do
 
     it 'deletes the account' do
       subject
-      expect(User.find(id: user.id)).to be(nil)
+      expect(User.first(id: user.id)).to be(nil)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Mutations::Account::DeleteAccountMutation do
 
     it 'does not delete the account' do
       subject
-      expect(User.find(id: user.id)).to_not be(nil)
+      expect(User.first(id: user.id)).to_not be(nil)
     end
   end
 

--- a/spec/graphql/mutations/account/sign_up_mutation_spec.rb
+++ b/spec/graphql/mutations/account/sign_up_mutation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Mutations::Account::SignUpMutation,
   subject { result }
 
   context 'successful' do
-    let(:user) { User.find(slug: user_data['username']) }
+    let(:user) { User.first(slug: user_data['username']) }
 
     context 'with immediate access' do
       before { subject }

--- a/spec/graphql/mutations/repository/create_repository_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/create_repository_mutation_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'createRepository mutation' do
     end
     it 'creates the git repository' do
       subject
-      repository = RepositoryCompound.find(name: repository_blueprint.name)
+      repository = RepositoryCompound.first(name: repository_blueprint.name)
       expect(repository.git.repo_exists?).to be(true)
     end
   end

--- a/spec/graphql/mutations/repository/delete_repository_mutation_spec.rb
+++ b/spec/graphql/mutations/repository/delete_repository_mutation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'deleteRepository mutation' do
 
     it 'deletes the repository' do
       subject
-      repo = Repository.find(slug: repository.slug)
+      repo = Repository.first(slug: repository.slug)
       expect(repo).to be_nil
     end
 

--- a/spec/graphql/types/git/commit_type_spec.rb
+++ b/spec/graphql/types/git/commit_type_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Types::Git::CommitType do
   let(:repository) { create(:repository_compound, :not_empty) }
   let(:revision) { repository.git.default_branch }
   subject { repository.git.commit(revision) }
-  let(:file_version) { FileVersion.find(commit_sha: subject.id) }
+  let(:file_version) { FileVersion.first(commit_sha: subject.id) }
   let(:type) { OntohubBackendSchema.types['Commit'] }
   let(:arguments) { {} }
   let(:resolved_field) { field.resolve(subject, arguments, {}) }

--- a/spec/lib/file_version_parents_creator_spec.rb
+++ b/spec/lib/file_version_parents_creator_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe(FileVersionParentsCreator) do
 
     it 'creates the "reflexive" FileVersionParents' do
       files.each do |file|
-        file_version = FileVersion.find(repository_id: repository.id,
-                                        commit_sha: commit_sha1,
-                                        path: file)
+        file_version = FileVersion.first(repository_id: repository.id,
+                                         commit_sha: commit_sha1,
+                                         path: file)
         expect(FileVersionParent.
                  find(queried_sha: commit_sha1,
                       last_changed_file_version: file_version)).
@@ -53,9 +53,9 @@ RSpec.describe(FileVersionParentsCreator) do
 
       it 'creates the backwards FileVersionParents' do
         files.each do |file|
-          file_version = FileVersion.find(repository_id: repository.id,
-                                          commit_sha: commit_sha1,
-                                          path: file)
+          file_version = FileVersion.first(repository_id: repository.id,
+                                           commit_sha: commit_sha1,
+                                           path: file)
           expect(FileVersionParent.
                    find(queried_sha: commit_sha2,
                         last_changed_file_version: file_version)).

--- a/spec/models/multi_blob_spec.rb
+++ b/spec/models/multi_blob_spec.rb
@@ -729,32 +729,32 @@ RSpec.describe MultiBlob do
       let!(:commit_sha) { subject.save }
 
       it 'creates a FileVersion for the created file' do
-        expect(FileVersion.find(commit_sha: commit_sha, path: new_files[0])).
+        expect(FileVersion.first(commit_sha: commit_sha, path: new_files[0])).
           to be_a(FileVersion)
       end
 
       it 'creates a FileVersion for the renamed file' do
-        expect(FileVersion.find(commit_sha: commit_sha, path: new_files[1])).
+        expect(FileVersion.first(commit_sha: commit_sha, path: new_files[1])).
           to be_a(FileVersion)
       end
 
       it 'creates a FileVersion for the updated file' do
-        expect(FileVersion.find(commit_sha: commit_sha, path: old_files[2])).
+        expect(FileVersion.first(commit_sha: commit_sha, path: old_files[2])).
           to be_a(FileVersion)
       end
 
       it 'creates a FileVersion for the updated and renamed file' do
-        expect(FileVersion.find(commit_sha: commit_sha, path: new_files[3])).
+        expect(FileVersion.first(commit_sha: commit_sha, path: new_files[3])).
           to be_a(FileVersion)
       end
 
       it 'does not create a FileVersion for the removed file' do
-        expect(FileVersion.find(commit_sha: commit_sha, path: old_files[4])).
+        expect(FileVersion.first(commit_sha: commit_sha, path: old_files[4])).
           to be(nil)
       end
 
       it 'creates a FileVersion for the created .gitkeep file' do
-        expect(FileVersion.find(commit_sha: commit_sha,
+        expect(FileVersion.first(commit_sha: commit_sha,
                                 path: File.join(new_files[5], '.gitkeep'))).
           to be_a(FileVersion)
       end

--- a/spec/shared_examples/confirmation_email.rb
+++ b/spec/shared_examples/confirmation_email.rb
@@ -20,11 +20,11 @@ RSpec.shared_examples 'a confirmation email sender' do
 
   it 'includes the confirmation token' do
     expect(last_email.body.encoded).
-      to include(User.find(email: user.email).confirmation_token)
+      to include(User.first(email: user.email).confirmation_token)
   end
 
   it 'includes a confirmation link' do
-    persisted_user = User.find(email: user.email)
+    persisted_user = User.first(email: user.email)
     token = persisted_user.confirmation_token
     # rubocop:disable Metrics/LineLength
     link = %(<a href="http://example.test/account/confirm-email?confirmation_token=#{token}">Confirm my account</a>)


### PR DESCRIPTION
Sequel encourages us [to use `Model.[]` or `Model.first` instead of `find`](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Model/ClassMethods.html#method-i-find). This pull request replaces all `find` by `first`.