### PR TITLE
Improve boot time.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'puma', '~> 3.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 
+# Improve boot time - This gem is not exposing a changing API, so we can leave
+# out the version requirement.
+gem 'bootsnap', require: false
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making
 # cross-origin AJAX possible
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.1.5)
+      msgpack (~> 1.0)
     bringit (1.0.0)
       activesupport (>= 4.0)
       charlock_holmes (~> 0.7.3)
@@ -223,6 +225,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    msgpack (1.1.0)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     nio4r (2.1.0)
@@ -387,6 +390,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print (~> 1.8.0)
+  bootsnap
   bringit (~> 1.0.0)
   bunny
   bunny-mock (~> 1.7.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,3 +3,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Reduce application booting time.


### PR DESCRIPTION
[Bootsnap](https://github.com/Shopify/bootsnap) is a gem that reduces the time to boot an application by changing how `require` operates. This gem is [included in the default Gemfile in Rails 5.2](http://weblog.rubyonrails.org/2017/11/27/Rails-5-2-Active-Storage-Redis-Cache-Store-HTTP2-Early-Hints-Credentials/). In a first test, we save about a second compared to the current master branch (according to the RSpec report).