### PR TITLE
Add fasterer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development do
   gem 'invoker'
   gem 'listen', '~> 3.1.5'
   gem 'rubocop', '~> 0.51.0', require: false
+  gem 'fasterer', require: false
   # Spring speeds up development by keeping your application running in the
   # background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ontohub/ontohub-models.git
-  revision: 81507f0cf1de24c156598dc07cf48f33172b300d
+  revision: 480a141e12d34b07b6532a59798e78bf524fc7f4
   branch: master
   specs:
     ontohub-models (0.1.0)
@@ -165,6 +165,9 @@ GEM
       i18n (>= 0.7)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    fasterer (0.3.2)
+      colorize (~> 0.7)
+      ruby_parser (~> 3.7)
     ffi (1.9.18)
     filelock (1.1.1)
     formatador (0.2.5)
@@ -328,6 +331,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    ruby_parser (3.10.1)
+      sexp_processor (~> 4.9)
     rubydns (0.8.5)
       eventmachine (~> 1.0.0)
     rugged (0.26.0)
@@ -347,6 +352,7 @@ GEM
       sequel
     serverengine (1.5.11)
       sigdump (~> 0.2.2)
+    sexp_processor (4.10.0)
     sigdump (0.2.4)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -399,6 +405,7 @@ DEPENDENCIES
   database_cleaner (~> 1.6.2)
   factory_bot_rails (~> 4.8.2)
   faker (~> 1.8.7)
+  fasterer
   filelock (~> 1.1.1)
   fuubar (~> 2.3.0)
   graphiql-rails


### PR DESCRIPTION
Part of #342. As `ruby_parser` does not yet support Ruby `2.5`, it emits a lot of noise telling you that it uses the `2.4` parser. For each file. These should go away once 2.5 is supported.

Run it with `bundle exec fasterer`

Related: https://github.com/houndci/linters/pull/174
  
  