### PR TITLE
Add RabbitMQ prefix and exchange options

### DIFF
--- a/app/jobs/post_process_hets_job.rb
+++ b/app/jobs/post_process_hets_job.rb
@@ -2,7 +2,7 @@
 
 # Post-processes a finished job that was sent to Hets
 class PostProcessHetsJob < ApplicationJob
-  queue_as :post_process_hets
+  queue_as "#{Settings.rabbitmq.prefix}_post_process_hets"
 
   def perform(result, original_job_message)
     return unless result == 'success'

--- a/app/jobs/process_commit_job.rb
+++ b/app/jobs/process_commit_job.rb
@@ -2,7 +2,7 @@
 
 # Post-processes a single commit
 class ProcessCommitJob < ApplicationJob
-  queue_as :process_commit
+  queue_as "#{Settings.rabbitmq.prefix}_process_commit"
 
   def perform(repository_id, commit_sha)
     FileVersionParentsCreator.new(repository_id, commit_sha).call

--- a/app/jobs/repository_cloning_job.rb
+++ b/app/jobs/repository_cloning_job.rb
@@ -2,7 +2,7 @@
 
 # Git clone finished job that was sent to Hets
 class RepositoryCloningJob < ApplicationJob
-  queue_as :git_clone
+  queue_as "#{Settings.rabbitmq.prefix}_git_clone"
 
   def perform(repository_slug)
     repository = Repository.first(slug: repository_slug)

--- a/app/jobs/repository_pulling_job.rb
+++ b/app/jobs/repository_pulling_job.rb
@@ -2,7 +2,7 @@
 
 # Git pull finished job that was sent to Hets
 class RepositoryPullingJob < ApplicationJob
-  queue_as :git_pull
+  queue_as "#{Settings.rabbitmq.prefix}_git_pull"
 
   def perform(repository_slug)
     repository = RepositoryCompound.first(slug: repository_slug)

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -3,7 +3,7 @@
 # Base class for all workers
 class ApplicationWorker
   include Sneakers::Worker
-  from_queue :default
+  from_queue "#{Settings.rabbitmq.prefix}_default"
 
   def work(msg)
     job_data = ActiveSupport::JSON.decode(msg)

--- a/app/workers/mailers_worker.rb
+++ b/app/workers/mailers_worker.rb
@@ -2,5 +2,5 @@
 
 # Worker for the mailers queue
 class MailersWorker < ApplicationWorker
-  from_queue :mailers, threads: 1, prefetch: 1
+  from_queue "#{Settings.rabbitmq.prefix}_mailers", threads: 1, prefetch: 1
 end

--- a/app/workers/post_process_hets_worker.rb
+++ b/app/workers/post_process_hets_worker.rb
@@ -2,5 +2,6 @@
 
 # Worker for the commit queue
 class PostProcessHetsWorker < ApplicationWorker
-  from_queue :post_process_hets, threads: 1, prefetch: 1, timeout_job_after: nil
+  from_queue "#{Settings.rabbitmq.prefix}_post_process_hets",
+    threads: 1, prefetch: 1, timeout_job_after: nil
 end

--- a/app/workers/process_commit_worker.rb
+++ b/app/workers/process_commit_worker.rb
@@ -2,5 +2,6 @@
 
 # Worker for the commit queue
 class ProcessCommitWorker < ApplicationWorker
-  from_queue :process_commit, threads: 1, prefetch: 1
+  from_queue "#{Settings.rabbitmq.prefix}_process_commit",
+    threads: 1, prefetch: 1
 end

--- a/app/workers/repository_cloning_worker.rb
+++ b/app/workers/repository_cloning_worker.rb
@@ -2,5 +2,6 @@
 
 # Worker for the git clone queue
 class RepositoryCloningWorker < ApplicationWorker
-  from_queue :git_clone, threads: 4, prefetch: 1, timeout_job_after: nil
+  from_queue "#{Settings.rabbitmq.prefix}_git_clone",
+    threads: 4, prefetch: 1, timeout_job_after: nil
 end

--- a/app/workers/repository_pulling_worker.rb
+++ b/app/workers/repository_pulling_worker.rb
@@ -2,5 +2,6 @@
 
 # Worker for the git pull queue
 class RepositoryPullingWorker < ApplicationWorker
-  from_queue :git_pull, threads: 4, prefetch: 1, timeout_job_after: nil
+  from_queue "#{Settings.rabbitmq.prefix}_git_pull",
+    threads: 4, prefetch: 1, timeout_job_after: nil
 end

--- a/config/initializers/hets_agent_initializer.rb
+++ b/config/initializers/hets_agent_initializer.rb
@@ -2,7 +2,7 @@
 
 # A service class that defines and sends the Hets version requirement.
 class HetsAgentIninializer
-  EXCHANGE_NAME = 'ex_hets_version_requirement'
+  EXCHANGE_NAME = "#{Settings.rabbitmq.exchange}_hets_version_requirement"
 
   attr_reader :connection
 

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -2,13 +2,15 @@
 
 if Rails.env.test?
   require Rails.root.join('spec/support/bunnymock_recent_history_exchange.rb')
-  Sneakers.configure(connection: BunnyMock.new)
+  Sneakers.configure(connection: BunnyMock.new,
+                     exchange: Settings.rabbitmq.exchange)
 else
   # :nocov:
   Sneakers.configure(connection: Bunny.new(username: Settings.rabbitmq.username,
                                            password: Settings.rabbitmq.password,
                                            host: Settings.rabbitmq.host,
-                                           port: Settings.rabbitmq.port))
+                                           port: Settings.rabbitmq.port),
+                     exchange: Settings.rabbitmq.exchange)
   Sneakers.logger.level = Logger::ERROR
   # :nocov:
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,7 @@ rabbitmq:
   username: guest
   password: guest
   prefix: ontohub
+  exchange: ontohub
 
 sneakers:
   - classes: MailersWorker

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,7 @@ rabbitmq:
   port: 5672
   username: guest
   password: guest
+  prefix: ontohub
 
 sneakers:
   - classes: MailersWorker

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,3 @@
 rabbitmq:
   prefix: ontohub_development
+  exchange: ontohub_development

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+rabbitmq:
+  prefix: ontohub_development

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,4 @@
 server_url: 'http://example.test'
 data_directory: 'tmp/data'
+rabbitmq:
+  prefix: ontohub_test

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,6 @@
 server_url: 'http://example.test'
 data_directory: 'tmp/data'
+
 rabbitmq:
   prefix: ontohub_test
+  exchange: ontohub_test

--- a/lib/hets_agent/invoker.rb
+++ b/lib/hets_agent/invoker.rb
@@ -5,7 +5,7 @@ module HetsAgent
   # HetsAgent to analyze them.
   class Invoker
     WORKER_QUEUE_NAME =
-      "hets #{OntohubBackend::Application.config.hets_version_requirement}"
+      "#{Settings.rabbitmq.prefix}_hets #{OntohubBackend::Application.config.hets_version_requirement}"
 
     attr_reader :request_collection
 

--- a/spec/factories/settings_factory.rb
+++ b/spec/factories/settings_factory.rb
@@ -11,6 +11,17 @@ FactoryBot.define do
 
     data_directory 'tmp/data'
 
-    sneakers [{workers: 2, classes: 'ApplicationWorker'}]
+    rabbitmq do
+      {
+        host: 'example.com',
+        port: 1234,
+        username: 'username',
+        password: 'password',
+        prefix: 'rabbitmq_test_prefix',
+        exchange: 'rabbitmq_test_exchange',
+      }
+    end
+
+    sneakers [{workers: 2, classes: 'MailersWorker'}]
   end
 end

--- a/spec/initializers/settings_schema_spec.rb
+++ b/spec/initializers/settings_schema_spec.rb
@@ -36,6 +36,37 @@ RSpec.describe(SettingsSchema) do
         to include(data_directory: ['must be filled'])
     end
 
+    context 'rabbitmq' do
+      %i(host username password prefix exchange).each do |field|
+        context field.to_s do
+          it 'is nil' do
+            settings[:rabbitmq][field] = nil
+            expect(subject.errors).
+              to include(rabbitmq: {field => ['must be filled']})
+          end
+
+          it 'is maltyped' do
+            settings[:rabbitmq][field] = 0
+            expect(subject.errors).
+              to include(rabbitmq: {field => ['must be a string']})
+          end
+        end
+      end
+      context 'port' do
+        it 'is nil' do
+          settings[:rabbitmq][:port] = nil
+          expect(subject.errors).
+            to include(rabbitmq: {port: ['must be filled']})
+        end
+
+        it 'is maltyped' do
+          settings[:rabbitmq][:port] = 'string'
+          expect(subject.errors).
+            to include(rabbitmq: {port: ['must be an integer']})
+        end
+      end
+    end
+
     context 'server_url' do
       it 'is not a string' do
         settings[:server_url] = 0

--- a/spec/jobs/post_process_hets_job_spec.rb
+++ b/spec/jobs/post_process_hets_job_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe PostProcessHetsJob, type: :job do
           expect { PostProcessHetsJob.new.perform(*job_message) }.
             to have_enqueued_job.
             with(*job_message).
-            on_queue('post_process_hets')
+            on_queue("#{Settings.rabbitmq.prefix}_post_process_hets")
         end
 
         it 'calls the ImportingDocumentsReanalyzer' do


### PR DESCRIPTION
This shall add prefix and exchange options for RabbitMQ. Queue names will be prefixed and the exchange will be chosen by the app. This is needed for the system-tests to not interfere with the backend seeds because the queues are emptied in the seeds (and they run in the system-tests).

This pull request is blocked because of #343: It still needs to validate the settings.