### PR TITLE
Include index gem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
         - EMAJ_SQL_FILE=$EMAJ_TMPDIR/e-maj-$EMAJ_VERSION/sql/emaj--$EMAJ_VERSION.sql
         - EMAJ_CONTROL_FILE=$EMAJ_TMPDIR/e-maj-$EMAJ_VERSION/emaj.control
         - SHAREDIR=$(pg_config --sharedir)
+        - sudo mkdir -p $SHAREDIR/extension/
         - sudo cp $EMAJ_SQL_FILE $EMAJ_CONTROL_FILE $SHAREDIR/extension/
       before_script:
         - |

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'rack-cors'
 gem 'ontohub-models', github: 'ontohub/ontohub-models',
                       branch: 'master'
 
+gem 'index', github: 'ontohub/index', branch: 'master', require: false
+
 gem 'bringit', '~> 1.0.0'
 
 gem 'config', '~> 1.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: git://github.com/ontohub/index.git
+  revision: fda77a3903045fb463142cc47e0627e1e69c1d0b
+  branch: master
+  specs:
+    index (0.0.0)
+      awesome_print (~> 1.8.0)
+      chewy (~> 0.10.1)
+      pry (~> 0.11.0)
+
+GIT
   remote: git://github.com/ontohub/ontohub-models.git
   revision: 9b9d9dda26e25900fcc25e44926b43b580ac8648
   branch: master
@@ -411,6 +421,7 @@ DEPENDENCIES
   graphql (~> 1.7.7)
   graphql-batch (~> 0.3.9)
   graphql-pundit (~> 0.5.1)
+  index!
   invoker
   json-schema!
   jwt (~> 2.1.0)


### PR DESCRIPTION
Now the [index gem](https://github.com/ontohub/index) is available in the backend and one can use, for instance, `Index::RepositoryIndex.query(match: {name: 'Fixtures'})`.