### PR TITLE
Fix system-tests on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ addons:
   postgresql: '9.6'
   apt:
     packages:
-    - git-svn
+      - postgresql-server-dev-9.6
+      - git-svn
 
 matrix:
   fast_finish: true
@@ -81,6 +82,7 @@ matrix:
         - pushd $HOME/system-test
         - bundle install
         - popd
+        - export RAILS_ENV=development
       script:
         - pushd $HOME/system-test
         - echo "Testing commit $TRAVIS_COMMIT"


### PR DESCRIPTION
There were two issues:
* The backend was started in test mode, so the wrong database was used
* Travis uses `pg_config` from PostgreSQL 10.1, so the `SHAREDIR` is using a path of version 10.1 instead of 9.6. Hence, the EMAJ extension cannot be installed.