### PR TITLE
Replace prefix and exchange settings by virtual host.

### DIFF
--- a/app/jobs/post_process_hets_job.rb
+++ b/app/jobs/post_process_hets_job.rb
@@ -2,7 +2,7 @@
 
 # Post-processes a finished job that was sent to Hets
 class PostProcessHetsJob < ApplicationJob
-  queue_as "#{Settings.rabbitmq.prefix}_post_process_hets"
+  queue_as 'post_process_hets'
 
   def perform(result, original_job_message)
     return unless result == 'success'

--- a/app/jobs/process_commit_job.rb
+++ b/app/jobs/process_commit_job.rb
@@ -2,7 +2,7 @@
 
 # Post-processes a single commit
 class ProcessCommitJob < ApplicationJob
-  queue_as "#{Settings.rabbitmq.prefix}_process_commit"
+  queue_as 'process_commit'
 
   def perform(repository_id, commit_sha)
     FileVersionParentsCreator.new(repository_id, commit_sha).call

--- a/app/jobs/repository_cloning_job.rb
+++ b/app/jobs/repository_cloning_job.rb
@@ -2,7 +2,7 @@
 
 # Git clone finished job that was sent to Hets
 class RepositoryCloningJob < ApplicationJob
-  queue_as "#{Settings.rabbitmq.prefix}_git_clone"
+  queue_as 'git_clone'
 
   def perform(repository_slug)
     repository = Repository.first(slug: repository_slug)

--- a/app/jobs/repository_pulling_job.rb
+++ b/app/jobs/repository_pulling_job.rb
@@ -2,7 +2,7 @@
 
 # Git pull finished job that was sent to Hets
 class RepositoryPullingJob < ApplicationJob
-  queue_as "#{Settings.rabbitmq.prefix}_git_pull"
+  queue_as 'git_pull'
 
   def perform(repository_slug)
     repository = RepositoryCompound.first(slug: repository_slug)

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -3,7 +3,7 @@
 # Base class for all workers
 class ApplicationWorker
   include Sneakers::Worker
-  from_queue "#{Settings.rabbitmq.prefix}_default"
+  from_queue 'default'
 
   def work(msg)
     job_data = ActiveSupport::JSON.decode(msg)

--- a/app/workers/mailers_worker.rb
+++ b/app/workers/mailers_worker.rb
@@ -2,5 +2,5 @@
 
 # Worker for the mailers queue
 class MailersWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_mailers", threads: 1, prefetch: 1
+  from_queue 'mailers', threads: 1, prefetch: 1
 end

--- a/app/workers/post_process_hets_worker.rb
+++ b/app/workers/post_process_hets_worker.rb
@@ -2,6 +2,6 @@
 
 # Worker for the commit queue
 class PostProcessHetsWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_post_process_hets",
+  from_queue 'post_process_hets',
     threads: 1, prefetch: 1, timeout_job_after: nil
 end

--- a/app/workers/process_commit_worker.rb
+++ b/app/workers/process_commit_worker.rb
@@ -2,6 +2,5 @@
 
 # Worker for the commit queue
 class ProcessCommitWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_process_commit",
-    threads: 1, prefetch: 1
+  from_queue 'process_commit', threads: 1, prefetch: 1
 end

--- a/app/workers/repository_cloning_worker.rb
+++ b/app/workers/repository_cloning_worker.rb
@@ -2,6 +2,5 @@
 
 # Worker for the git clone queue
 class RepositoryCloningWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_git_clone",
-    threads: 4, prefetch: 1, timeout_job_after: nil
+  from_queue 'git_clone', threads: 4, prefetch: 1, timeout_job_after: nil
 end

--- a/app/workers/repository_pulling_worker.rb
+++ b/app/workers/repository_pulling_worker.rb
@@ -2,6 +2,5 @@
 
 # Worker for the git pull queue
 class RepositoryPullingWorker < ApplicationWorker
-  from_queue "#{Settings.rabbitmq.prefix}_git_pull",
-    threads: 4, prefetch: 1, timeout_job_after: nil
+  from_queue 'git_pull', threads: 4, prefetch: 1, timeout_job_after: nil
 end

--- a/config/initializers/hets_agent_initializer.rb
+++ b/config/initializers/hets_agent_initializer.rb
@@ -2,7 +2,7 @@
 
 # A service class that defines and sends the Hets version requirement.
 class HetsAgentIninializer
-  EXCHANGE_NAME = "#{Settings.rabbitmq.exchange}_hets_version_requirement"
+  EXCHANGE_NAME = 'hets_version_requirement'
 
   attr_reader :connection
 

--- a/config/initializers/settings_schema.rb
+++ b/config/initializers/settings_schema.rb
@@ -78,8 +78,7 @@ class SettingsSchema < Dry::Validation::Schema
       required(:port).filled { int? }
       required(:username).filled { str? }
       required(:password).filled { str? }
-      required(:prefix).filled { str? }
-      required(:exchange).filled { str? }
+      required(:virtual_host).filled { str? }
     end
 
     required(:sneakers).each do

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -2,15 +2,16 @@
 
 if Rails.env.test?
   require Rails.root.join('spec/support/bunnymock_recent_history_exchange.rb')
-  Sneakers.configure(connection: BunnyMock.new,
-                     exchange: Settings.rabbitmq.exchange)
+  Sneakers.configure(connection: BunnyMock.new)
 else
   # :nocov:
-  Sneakers.configure(connection: Bunny.new(username: Settings.rabbitmq.username,
-                                           password: Settings.rabbitmq.password,
-                                           host: Settings.rabbitmq.host,
-                                           port: Settings.rabbitmq.port),
-                     exchange: Settings.rabbitmq.exchange)
+  Sneakers.
+    configure(connection:
+              Bunny.new(username: Settings.rabbitmq.username,
+                        password: Settings.rabbitmq.password,
+                        host: Settings.rabbitmq.host,
+                        port: Settings.rabbitmq.port,
+                        virtual_host: Settings.rabbitmq.virtual_host))
   Sneakers.logger.level = Logger::ERROR
   # :nocov:
 end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -12,6 +12,6 @@ else
                         host: Settings.rabbitmq.host,
                         port: Settings.rabbitmq.port,
                         virtual_host: Settings.rabbitmq.virtual_host))
-  Sneakers.logger.level = Logger::ERROR
+  Sneakers.logger.level = Logger::INFO
   # :nocov:
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,8 +14,7 @@ rabbitmq:
   port: 5672
   username: guest
   password: guest
-  prefix: ontohub
-  exchange: ontohub
+  virtual_host: ontohub_development
 
 sneakers:
   - classes: MailersWorker

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+rabbitmq:
+  virtual_host: ontohub

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,5 +2,4 @@ server_url: 'http://example.test'
 data_directory: 'tmp/data'
 
 rabbitmq:
-  prefix: ontohub_test
-  exchange: ontohub_test
+  virtual_host: ontohub_test

--- a/lib/hets_agent/invoker.rb
+++ b/lib/hets_agent/invoker.rb
@@ -5,7 +5,7 @@ module HetsAgent
   # HetsAgent to analyze them.
   class Invoker
     WORKER_QUEUE_NAME =
-      "#{Settings.rabbitmq.prefix}_hets #{OntohubBackend::Application.config.hets_version_requirement}"
+      "hets #{OntohubBackend::Application.config.hets_version_requirement}"
 
     attr_reader :request_collection
 

--- a/lib/tasks/invoker.rake
+++ b/lib/tasks/invoker.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+RAKE_INVOKER_DATABASE_PROCESSES =
+  %w(ontohub-backend sneakers hets-agent indexer).freeze
+
 desc 'Runs the development server'
 task :invoker do
   exec(%(bundle exec invoker start invoker.ini))
@@ -8,14 +11,14 @@ end
 namespace :invoker do
   desc 'Stops all processes that are using the database'
   task :stop_all do
-    %w(ontohub-backend sneakers hets-agent).each do |process|
+    RAKE_INVOKER_DATABASE_PROCESSES.each do |process|
       system("bundle exec invoker remove #{process} 1> /dev/null 2> /dev/null")
     end
   end
 
   desc 'Starts all processes that are using the database'
   task :start_all do
-    %w(ontohub-backend sneakers hets-agent).each do |process|
+    RAKE_INVOKER_DATABASE_PROCESSES.each do |process|
       system("bundle exec invoker add #{process} 1> /dev/null 2> /dev/null")
     end
   end

--- a/spec/factories/settings_factory.rb
+++ b/spec/factories/settings_factory.rb
@@ -17,8 +17,7 @@ FactoryBot.define do
         port: 1234,
         username: 'username',
         password: 'password',
-        prefix: 'rabbitmq_test_prefix',
-        exchange: 'rabbitmq_test_exchange',
+        virtual_host: 'rabbitmq_test',
       }
     end
 

--- a/spec/initializers/settings_schema_spec.rb
+++ b/spec/initializers/settings_schema_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe(SettingsSchema) do
     end
 
     context 'rabbitmq' do
-      %i(host username password prefix exchange).each do |field|
+      %i(host username password virtual_host).each do |field|
         context field.to_s do
           it 'is nil' do
             settings[:rabbitmq][field] = nil

--- a/spec/jobs/post_process_hets_job_spec.rb
+++ b/spec/jobs/post_process_hets_job_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe PostProcessHetsJob, type: :job do
           expect { PostProcessHetsJob.new.perform(*job_message) }.
             to have_enqueued_job.
             with(*job_message).
-            on_queue("#{Settings.rabbitmq.prefix}_post_process_hets")
+            on_queue('post_process_hets')
         end
 
         it 'calls the ImportingDocumentsReanalyzer' do


### PR DESCRIPTION
This simplifies the configuration of rabbitmq. However, this does not solve the actual problem that jobs can't be published (causing a timeout).