### PR TITLE
Fix Processes and Version Check in the System Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,21 +70,24 @@ matrix:
         - sudo mkdir -p $SHAREDIR/extension/
         - sudo cp $EMAJ_SQL_FILE $EMAJ_CONTROL_FILE $SHAREDIR/extension/
       before_script:
+        - sudo rabbitmqctl add_vhost ontohub_system_test
+        - sudo rabbitmqctl set_permissions -p ontohub_system_test guest ".*" ".*" ".*"
         - |
+          rm -rf $HOME/system-test
           if [ -d $HOME/system-test/.git ]
           then
             pushd $HOME/system-test
             git pull
             popd
           else
-            git clone --depth=1 https://github.com/ontohub/system-test.git $HOME/system-test
+            git clone https://github.com/ontohub/system-test.git $HOME/system-test
           fi
         - pushd $HOME/system-test
+        - git checkout switch_to_rspec_and_add_git_shell_tests
         - bundle install
         - popd
-        - export RAILS_ENV=development
       script:
         - pushd $HOME/system-test
         - echo "Testing commit $TRAVIS_COMMIT"
-        - ONTOHUB_BACKEND_VERSION=$TRAVIS_COMMIT cucumber
+        - INDEXER_VERSION=fix_production_environment ONTOHUB_BACKEND_VERSION=$TRAVIS_COMMIT bundle exec rspec
         - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ matrix:
         - sudo rabbitmqctl add_vhost ontohub_system_test
         - sudo rabbitmqctl set_permissions -p ontohub_system_test guest ".*" ".*" ".*"
         - |
-          rm -rf $HOME/system-test
           if [ -d $HOME/system-test/.git ]
           then
             pushd $HOME/system-test
@@ -83,11 +82,10 @@ matrix:
             git clone https://github.com/ontohub/system-test.git $HOME/system-test
           fi
         - pushd $HOME/system-test
-        - git checkout switch_to_rspec_and_add_git_shell_tests
         - bundle install
         - popd
       script:
         - pushd $HOME/system-test
         - echo "Testing commit $TRAVIS_COMMIT"
-        - INDEXER_VERSION=fix_production_environment ONTOHUB_BACKEND_VERSION=$TRAVIS_COMMIT bundle exec rspec
+        - ONTOHUB_BACKEND_VERSION=$TRAVIS_COMMIT bundle exec rspec
         - popd

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -39,12 +39,12 @@ class Version
 
     # :nocov:
     def production?
-      Rails.env.production?
+      Rails.env.production? && ENV['ONTOHUB_SYSTEM_TEST'] != 'true'
     end
     # :nocov:
 
     def test?
-      Rails.env.test? && !ENV['ONTOHUB_SYSTEM_TEST']
+      Rails.env.test?
     end
 
     # :nocov:

--- a/lib/sneakers/multi_runner.rb
+++ b/lib/sneakers/multi_runner.rb
@@ -29,10 +29,17 @@ module Sneakers
         Signal.trap(signal) do
           @pids.each do |pid|
             Process.kill(signal, pid)
+          rescue Errno::ESRCH
+            warn_about_missing_process(signal, pid)
           end
         end
       end
       Process.waitall
+    end
+
+    def warn_about_missing_process(signal, pid)
+      warn("Failed to send signal #{signal} to PID #{pid}: "\
+           'Process does not exist.')
     end
   end
 end


### PR DESCRIPTION
The system-tests fail when stopping all the applications because the multi runner's processes are already dead and the multi-runner itself can't kill them any more. This should fix that problem.

I'm currently changing the system-tests to start all applications in the production environment. The second commit fixes the version check for this purpose.