### PR TITLE
Update rubocop config.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,8 @@ AllCops:
     - 'node_modules/**/*'
     - 'spec/dummy/**/*'
     - 'vendor/**/*'
-    - 'repos/**/*'
+    - 'repositories/**/*'
+    - 'tmp/**/*'
 
 Layout/AlignParameters:
   Enabled: false
@@ -37,6 +38,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/environments/**/*'
     - 'config/initializers/devise.rb'
+    - 'lib/tasks/**/*.rake'
     - 'spec/**/*'
     - 'db/migrate/*'
     - '*.gemspec'
@@ -45,19 +47,23 @@ Metrics/LineLength:
   Exclude:
     - 'app/graphql/**/*_enum.rb'
     - 'config/initializers/devise.rb'
-    - 'features/steps/**/*.rb'
+
+Naming/FileName:
+  Exclude:
+    - lib/git-shell.rb
+    - lib/hets-agent.rb
+    - lib/ontohub-models.rb
+    - spec/lib/git-shell_spec.rb
+
+Style/Documentation:
+  Exclude:
+    - 'app/indexers/**/*'
 
 Style/DoubleNegation:
   Enabled: false
 
 Style/FormatStringToken:
   Enabled: false
-
-Style/GlobalVars:
-  Exclude:
-    - 'features/steps/**/*.rb'
-    - 'features/support/aruba.rb'
-    - 'features/support/hooks.rb'
 
 Style/NumericLiterals:
   Enabled: false

--- a/lib/tasks/apidoc.rake
+++ b/lib/tasks/apidoc.rake
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'fileutils'
-
-# rubocop:disable Metrics/BlockLength
 namespace :apidoc do
   # rubocop:enable Metrics/BlockLength
   APIDOC_DIR = Rails.root.join('apidoc').to_s

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -10,7 +10,7 @@ namespace :db do
     Rake::Task['db:seed'].invoke
   end
 
-  desc "Truncate all tables"
+  desc 'Truncate all tables'
   task truncate: ['rabbitmq:purge', 'repo:clean'] do
     db = Sequel::Model.db
     tables = db.tables - %i(schema_migrations)
@@ -27,7 +27,7 @@ namespace :db do
       Rake::Task['db:seed'].invoke
     end
 
-    desc "Recreate all tables"
+    desc 'Recreate all tables'
     task tables: ['rabbitmq:purge', 'repo:clean'] do
       db = Sequel::Model.db
       all_tables = db.tables.map do |table|

--- a/lib/tasks/rabbitmq.rake
+++ b/lib/tasks/rabbitmq.rake
@@ -8,10 +8,10 @@ QUEUES = %w(
   mailers
   post_process_hets
   process_commit
-)
+).freeze
 
 namespace :rabbitmq do
-  desc "Purge all rabbitmq queues"
+  desc 'Purge all rabbitmq queues'
   task :purge do
     next if Rails.env.test?
     connection = Bunny.new(username: Settings.rabbitmq.username,

--- a/spec/support/bunnymock_recent_history_exchange.rb
+++ b/spec/support/bunnymock_recent_history_exchange.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module BunnyMock
+  # Mock the recent history exchange extension of RabbitMQ.
   class Exchange
     # Monkeypatch, XRecentHistory be found by the ex declare "x-recent-history"
     def self.declare(channel, name = '', **opts)
@@ -14,6 +15,7 @@ module BunnyMock
     end
   end
 
+  # Mock the recent history exchange extension of RabbitMQ.
   module Exchanges
     class XRecentHistory < BunnyMock::Exchanges::Fanout
     end

--- a/spec/support/controller_login_helpers.rb
+++ b/spec/support/controller_login_helpers.rb
@@ -2,6 +2,7 @@
 
 # Helper methods for user login handling in controller specs
 module ControllerLoginHelpers
+  # Helper methods for user login handling in controller spec contexts
   module ClassHelpers
     def create_user_and_sign_in
       before(:each) do
@@ -15,6 +16,7 @@ module ControllerLoginHelpers
     end
   end
 
+  # Helper methods for user login handling in controller spec examples
   module InstanceHelpers
     def create_user_and_set_token_header
       user = FactoryBot.create(:user)

--- a/spec/support/graphql_helpers.rb
+++ b/spec/support/graphql_helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module GraphQL
+  # Helper functions for the GraphQL specs.
   class Field
     def default_arguments(args = {})
       arguments.transform_values(&:default_value).merge(args)

--- a/spec/support/mailer_helpers.rb
+++ b/spec/support/mailer_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Helper functions for specs that check emails.
 module MailerHelpers
   def emails
     ActionMailer::Base.deliveries

--- a/spec/support/tempdir.rb
+++ b/spec/support/tempdir.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Run all examples in a temp directory
 module Tempdir
   def self.with_tempdir
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
This updates the rubocop config. It builds on top of #382 and adds some more rules that only apply to the other ruby-based repositores. This fixes some style-offenses, too.

It is the same config file as in
* https://github.com/ontohub/system-test/pull/43
* https://github.com/ontohub/git-shell/pull/2
* https://github.com/ontohub/ontohub-models/pull/161
* https://github.com/ontohub/hets-agent/pull/64
* https://github.com/ontohub/indexer/pull/11